### PR TITLE
feat: v2026.0.APR.1 — multi-stream accuracy + side panel + scheduled tests + UX polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ yarn-error.log*
 .idea/
 .vscode/
 *.swp
+.claude/settings.local.json
 
 # OS
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,53 @@
         "vitest": "^3.0.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -30,6 +77,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -161,6 +220,140 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -828,6 +1021,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1418,6 +1628,10 @@
     },
     "node_modules/@meterx/server": {
       "resolved": "packages/server",
+      "link": true
+    },
+    "node_modules/@meterx/shared": {
+      "resolved": "packages/shared",
       "link": true
     },
     "node_modules/@meterx/worker": {
@@ -2623,6 +2837,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -2963,6 +3186,38 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2979,6 +3234,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.1.0",
@@ -3112,6 +3373,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -3925,6 +4198,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -4057,6 +4342,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4088,6 +4379,55 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/json-buffer": {
@@ -4202,6 +4542,15 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5368,6 +5717,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -5599,6 +5960,15 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5740,6 +6110,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6072,6 +6454,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -6173,6 +6561,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6193,6 +6599,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7102,6 +7532,50 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7720,6 +8194,21 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7808,11 +8297,13 @@
       "version": "2026.0.319-MR1.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@meterx/shared": "*",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1"
       },
       "devDependencies": {
-        "@types/chrome": "^0.0.287"
+        "@types/chrome": "^0.0.287",
+        "jsdom": "^29.0.2"
       }
     },
     "packages/server": {
@@ -7820,6 +8311,7 @@
       "version": "2026.0.319-MR1.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@meterx/shared": "*",
         "cors": "^2.8.5",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.0"
@@ -7832,10 +8324,18 @@
         "supertest": "^7.0.0"
       }
     },
+    "packages/shared": {
+      "name": "@meterx/shared",
+      "version": "1.0.0",
+      "license": "AGPL-3.0"
+    },
     "packages/worker": {
       "name": "@meterx/worker",
       "version": "2026.0.319-MR1.0",
       "license": "AGPL-3.0",
+      "dependencies": {
+        "@meterx/shared": "*"
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250313.0",
         "wrangler": "^4.8.0"

--- a/packages/extension/build.mjs
+++ b/packages/extension/build.mjs
@@ -11,6 +11,7 @@ await build({
         resolve(__dirname, 'src/background.ts'),
         resolve(__dirname, 'src/popup.ts'),
         resolve(__dirname, 'src/options.ts'),
+        resolve(__dirname, 'src/sidepanel.ts'),
     ],
     bundle: true,
     outdir: resolve(__dirname, 'dist'),

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -4,12 +4,15 @@
   "private": true,
   "license": "AGPL-3.0",
   "scripts": {
-    "build": "node build.mjs"
+    "build": "node build.mjs",
+    "test": "npx vitest run"
   },
   "devDependencies": {
-    "@types/chrome": "^0.0.287"
+    "@types/chrome": "^0.0.287",
+    "jsdom": "^29.0.2"
   },
   "dependencies": {
+    "@meterx/shared": "*",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1"
   }

--- a/packages/extension/src/background.ts
+++ b/packages/extension/src/background.ts
@@ -7,17 +7,27 @@
 
 /// <reference types="chrome" />
 
+import type { TestProgress, TestResults, PingResult } from '@meterx/shared';
+
 // --- Configuration ---
 const DEFAULT_SERVER_URL = 'https://meterx-speedtest.meterx-ajithakdev.workers.dev';
-const DOWNLOAD_FILE_MB = 10; // 10MB for better TCP ramp-up (M-Lab uses 9-60s tests)
-const DOWNLOAD_FILE_PATH = `/test-file/${DOWNLOAD_FILE_MB}MB.bin`;
-const UPLOAD_DATA_SIZE_MB = 5;
+const DOWNLOAD_CHUNK_MB = 25; // biggest allowed chunk per stream (server whitelist max)
+const DOWNLOAD_CHUNK_PATH = `/test-file/${DOWNLOAD_CHUNK_MB}MB.bin`;
+const UPLOAD_CHUNK_MB = 5; // body size per POST stream
 const UPLOAD_ENDPOINT_PATH = '/upload';
 const PING_ENDPOINT_PATH = '/ping';
 const PING_COUNT = 5;
-const FETCH_DOWNLOAD_TIMEOUT = 60000;
-const FETCH_UPLOAD_TIMEOUT = 60000;
+// Multi-stream duration-based measurement — matches M-Lab / Ookla approach.
+// 4 parallel streams let us saturate typical home links up to ~gigabit.
+const PARALLEL_DOWNLOAD_STREAMS = 4;
+const PARALLEL_UPLOAD_STREAMS = 3;
+const MEASURE_DURATION_MS = 8000;
+const RAMP_UP_TRIM_MS = 1200; // drop first 1.2s while TCP ramps up
+const TAIL_TRIM_MS = 500;      // drop last 0.5s to avoid partial chunk skew
 const FETCH_PING_TIMEOUT = 5000;
+const LOADED_PING_INTERVAL_MS = 300; // probe ping every 300ms during load
+const SCHEDULE_ALARM_NAME = 'meterx-scheduled-test';
+const QUALITY_DROP_NOTIFICATION_ID = 'meterx-quality-drop';
 
 // --- Server URL (configurable via options page) ---
 async function getServerUrl(): Promise<string> {
@@ -29,29 +39,13 @@ async function getServerUrl(): Promise<string> {
     }
 }
 
-// --- Types ---
-interface TestProgress {
-    status?: string;
-    downloadSpeed?: number;
-    uploadSpeed?: number;
-    ping?: number;
-    jitter?: number;
-    packetLoss?: number;
-}
-
-interface TestResults {
-    downloadSpeed?: number;
-    uploadSpeed?: number;
-    ping?: number;
-    jitter?: number;
-    packetLoss?: number;
-    status: string;
-}
-
-interface PingResult {
-    ping: number;
-    jitter: number;
-    packetLoss: number;
+// --- Bufferbloat grading ---
+function gradeBufferbloat(deltaMs: number): 'A' | 'B' | 'C' | 'D' | 'F' {
+    if (deltaMs <= 5) return 'A';
+    if (deltaMs <= 30) return 'B';
+    if (deltaMs <= 60) return 'C';
+    if (deltaMs <= 200) return 'D';
+    return 'F';
 }
 
 // --- Messaging Helpers ---
@@ -99,6 +93,106 @@ async function fetchWithTimeout(resource: string, options: RequestInit = {}, tim
 
 // --- Test Functions ---
 
+// Loaded-ping probe: fires HEAD /ping on an interval while a flag is live.
+// Returns array of observed latencies in ms. Never throws — individual probe
+// failures are silently skipped because we only care about aggregate delay.
+interface LoadedPingHandle {
+    stop: () => Promise<number[]>;
+}
+
+function startLoadedPingProbe(baseUrl: string): LoadedPingHandle {
+    const samples: number[] = [];
+    let stopped = false;
+    let wakeSleep: (() => void) | null = null;
+
+    async function loop(): Promise<void> {
+        while (!stopped) {
+            const t0 = performance.now();
+            try {
+                const ctl = new AbortController();
+                const to = setTimeout(() => ctl.abort(), FETCH_PING_TIMEOUT);
+                const res = await fetch(`${baseUrl}${PING_ENDPOINT_PATH}?load=${Date.now()}`, { method: 'HEAD', cache: 'no-store', signal: ctl.signal });
+                clearTimeout(to);
+                if (res.ok) samples.push(performance.now() - t0);
+            } catch { /* skip */ }
+            if (stopped) break;
+            // Sleep, but be interruptible by stop() so the loop doesn't hang
+            // the outer `await runner` when tests cancel fast.
+            await new Promise<void>(resolve => {
+                const timer = setTimeout(() => { wakeSleep = null; resolve(); }, LOADED_PING_INTERVAL_MS);
+                wakeSleep = () => { clearTimeout(timer); wakeSleep = null; resolve(); };
+            });
+        }
+    }
+
+    const runner = loop();
+
+    return {
+        stop: async () => {
+            stopped = true;
+            if (wakeSleep) wakeSleep();
+            await runner;
+            return samples;
+        },
+    };
+}
+
+async function detectIpFamily(baseUrl: string): Promise<{ ipv4Ok?: boolean; ipv6Ok?: boolean }> {
+    try {
+        const res = await fetchWithTimeout(`${baseUrl}/ip?t=${Date.now()}`, { cache: 'no-store' }, 5000);
+        if (!res.ok) return {};
+        const data = await res.json() as { family?: string };
+        if (data.family === 'ipv4') return { ipv4Ok: true };
+        if (data.family === 'ipv6') return { ipv6Ok: true };
+        return {};
+    } catch {
+        return {};
+    }
+}
+
+function extractDnsMs(urlPrefix: string): number | undefined {
+    // Scan recent resource entries for the most recent request to our server.
+    // Returns domainLookupEnd - domainLookupStart if the origin honored
+    // Timing-Allow-Origin; otherwise returns undefined (zeros are filtered out).
+    try {
+        const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+        for (let i = entries.length - 1; i >= 0; i--) {
+            const e = entries[i];
+            if (!e.name.startsWith(urlPrefix)) continue;
+            const dns = e.domainLookupEnd - e.domainLookupStart;
+            if (dns > 0) return dns;
+        }
+    } catch { /* no perf api */ }
+    return undefined;
+}
+
+// Timestamped cumulative-bytes sample used by windowed speed calc.
+interface ByteSample { t: number; bytes: number }
+
+// Given samples ordered by t, return cumulative bytes at time tTarget
+// by linear interpolation between adjacent samples.
+function bytesAtTime(samples: ByteSample[], tTarget: number): number {
+    if (samples.length === 0) return 0;
+    if (tTarget <= samples[0].t) return samples[0].bytes;
+    if (tTarget >= samples[samples.length - 1].t) return samples[samples.length - 1].bytes;
+    for (let i = 1; i < samples.length; i++) {
+        if (samples[i].t >= tTarget) {
+            const a = samples[i - 1];
+            const b = samples[i];
+            const ratio = (tTarget - a.t) / (b.t - a.t || 1);
+            return a.bytes + (b.bytes - a.bytes) * ratio;
+        }
+    }
+    return samples[samples.length - 1].bytes;
+}
+
+function speedFromWindow(samples: ByteSample[], startMs: number, endMs: number): number {
+    const durS = (endMs - startMs) / 1000;
+    if (durS <= 0) return 0;
+    const delta = bytesAtTime(samples, endMs) - bytesAtTime(samples, startMs);
+    return (delta * 8 / durS) / (1024 * 1024);
+}
+
 async function measureDownloadSpeed(baseUrl: string): Promise<number> {
     // Warm-up: establish TCP + TLS connection before timing
     await sendProgress({ status: 'Warming up connection...' });
@@ -107,50 +201,66 @@ async function measureDownloadSpeed(baseUrl: string): Promise<number> {
     } catch { /* warmup failure is non-fatal */ }
 
     await sendProgress({ status: 'Downloading test file...' });
-    const url = `${baseUrl}${DOWNLOAD_FILE_PATH}?t=${Date.now()}`;
-
-    const response = await fetchWithTimeout(url, { cache: 'no-store' }, FETCH_DOWNLOAD_TIMEOUT);
-    if (!response.ok) {
-        throw new Error(`Download failed: ${response.status} ${response.statusText}`);
-    }
-
-    // Stream the response to show live progress, measure total bytes / total time
-    const reader = response.body?.getReader();
-    if (!reader) {
-        const data = await response.arrayBuffer();
-        const endTime = performance.now();
-        const dur = (endTime - performance.now()) / 1000 || 1;
-        return (data.byteLength * 8 / dur) / (1024 * 1024);
-    }
 
     let totalBytes = 0;
     const startTime = performance.now();
-    let lastProgressBytes = 0;
+    const testEndTarget = startTime + MEASURE_DURATION_MS;
+    const samples: ByteSample[] = [{ t: 0, bytes: 0 }];
+    const controllers: AbortController[] = [];
+    let lastProgressMs = 0;
 
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        totalBytes += value.byteLength;
-        lastProgressBytes += value.byteLength;
+    async function streamOne(streamId: number): Promise<void> {
+        while (performance.now() < testEndTarget && !testAbortController?.signal.aborted) {
+            const ctl = new AbortController();
+            controllers.push(ctl);
+            try {
+                const res = await fetch(`${baseUrl}${DOWNLOAD_CHUNK_PATH}?t=${Date.now()}_${streamId}`, {
+                    cache: 'no-store',
+                    signal: ctl.signal,
+                });
+                if (!res.ok || !res.body) throw new Error(`stream ${streamId} http ${res.status}`);
+                const reader = res.body.getReader();
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    if (performance.now() >= testEndTarget) {
+                        try { await reader.cancel(); } catch { /* ignore */ }
+                        try { ctl.abort(); } catch { /* ignore */ }
+                        break;
+                    }
+                    totalBytes += value.byteLength;
+                    const t = performance.now() - startTime;
+                    samples.push({ t, bytes: totalBytes });
 
-        // Send live speed updates every ~500KB
-        if (lastProgressBytes >= 512 * 1024) {
-            const now = performance.now();
-            const elapsed = (now - startTime) / 1000;
-            if (elapsed > 0) {
-                const liveSpeed = (totalBytes * 8 / elapsed) / (1024 * 1024);
-                await sendProgress({ downloadSpeed: liveSpeed, status: 'Downloading...' });
-            }
-            lastProgressBytes = 0;
+                    if (t - lastProgressMs > 250) {
+                        lastProgressMs = t;
+                        const elapsedS = t / 1000;
+                        if (elapsedS > 0.5) {
+                            const liveSpeed = (totalBytes * 8 / elapsedS) / (1024 * 1024);
+                            await sendProgress({ downloadSpeed: liveSpeed, status: 'Downloading...' });
+                        }
+                    }
+                }
+            } catch { /* stream dropped or aborted — another iteration will take over */ }
         }
     }
 
-    const endTime = performance.now();
-    const totalDuration = (endTime - startTime) / 1000;
-    if (totalDuration === 0) throw new Error("Download too fast to measure");
+    const streams = Array.from({ length: PARALLEL_DOWNLOAD_STREAMS }, (_, i) => streamOne(i));
+    const hardDeadline = new Promise<void>(resolve => setTimeout(resolve, MEASURE_DURATION_MS + 2000));
+    await Promise.race([Promise.all(streams), hardDeadline]);
+    controllers.forEach(c => { try { c.abort(); } catch { /* ignore */ } });
 
-    // Simple total bytes / total time — same method as M-Lab
-    const speedMbps = (totalBytes * 8 / totalDuration) / (1024 * 1024);
+    // Windowed speed: trim ramp-up and tail to get steady-state throughput.
+    const usableEnd = Math.min(MEASURE_DURATION_MS - TAIL_TRIM_MS, performance.now() - startTime);
+    const windowStart = RAMP_UP_TRIM_MS;
+    if (usableEnd <= windowStart) {
+        // test was too short — fall back to naive total/time
+        const totalS = (performance.now() - startTime) / 1000 || 0.001;
+        const speed = (totalBytes * 8 / totalS) / (1024 * 1024);
+        await sendProgress({ downloadSpeed: speed, status: 'Download complete' });
+        return speed;
+    }
+    const speedMbps = speedFromWindow(samples, windowStart, usableEnd);
     await sendProgress({ downloadSpeed: speedMbps, status: 'Download complete' });
     return speedMbps;
 }
@@ -163,25 +273,67 @@ async function measureUploadSpeed(baseUrl: string): Promise<number> {
     } catch { /* non-fatal */ }
 
     await sendProgress({ status: 'Uploading test data...' });
-    const url = `${baseUrl}${UPLOAD_ENDPOINT_PATH}?t=${Date.now()}`;
-    const dataSize = UPLOAD_DATA_SIZE_MB * 1024 * 1024;
-    const dataToSend = new Uint8Array(dataSize);
 
+    const uploadSize = UPLOAD_CHUNK_MB * 1024 * 1024;
+    const payload = new Uint8Array(uploadSize); // shared across streams, immutable
+
+    let totalBytes = 0;
     const startTime = performance.now();
-    const response = await fetchWithTimeout(url, {
-        method: 'POST',
-        cache: 'no-store',
-        headers: { 'Content-Type': 'application/octet-stream' },
-        body: dataToSend
-    }, FETCH_UPLOAD_TIMEOUT);
-    if (!response.ok) throw new Error(`Upload failed: ${response.status}`);
-    await response.text();
-    const endTime = performance.now();
-    const durationSeconds = (endTime - startTime) / 1000;
-    if (durationSeconds === 0) throw new Error("Upload too fast to measure");
+    const endTarget = startTime + MEASURE_DURATION_MS;
+    const samples: ByteSample[] = [{ t: 0, bytes: 0 }];
+    const controllers: AbortController[] = [];
+    let lastProgressMs = 0;
 
-    const bitsUploaded = dataSize * 8;
-    const speedMbps = (bitsUploaded / durationSeconds) / (1024 * 1024);
+    async function uploadOne(streamId: number): Promise<void> {
+        while (performance.now() < endTarget && !testAbortController?.signal.aborted) {
+            const ctl = new AbortController();
+            controllers.push(ctl);
+            const chunkStart = performance.now();
+            try {
+                const res = await fetch(`${baseUrl}${UPLOAD_ENDPOINT_PATH}?t=${Date.now()}_${streamId}`, {
+                    method: 'POST',
+                    cache: 'no-store',
+                    headers: { 'Content-Type': 'application/octet-stream' },
+                    body: payload,
+                    signal: ctl.signal,
+                });
+                if (!res.ok) throw new Error(`upload ${streamId} http ${res.status}`);
+                await res.text();
+                // Credit bytes at completion time (fetch API won't stream upload progress in MV3)
+                totalBytes += uploadSize;
+                const t = performance.now() - startTime;
+                samples.push({ t, bytes: totalBytes });
+
+                if (t - lastProgressMs > 250) {
+                    lastProgressMs = t;
+                    const elapsedS = t / 1000;
+                    if (elapsedS > 0.5) {
+                        const liveSpeed = (totalBytes * 8 / elapsedS) / (1024 * 1024);
+                        await sendProgress({ uploadSpeed: liveSpeed, status: 'Uploading...' });
+                    }
+                }
+                // Avoid an endless-fast loop for tiny chunks
+                if (performance.now() - chunkStart < 50) {
+                    await new Promise(r => setTimeout(r, 50));
+                }
+            } catch { /* drop this stream iteration */ }
+        }
+    }
+
+    const streams = Array.from({ length: PARALLEL_UPLOAD_STREAMS }, (_, i) => uploadOne(i));
+    const hardDeadline = new Promise<void>(resolve => setTimeout(resolve, MEASURE_DURATION_MS + 2000));
+    await Promise.race([Promise.all(streams), hardDeadline]);
+    controllers.forEach(c => { try { c.abort(); } catch { /* ignore */ } });
+
+    const usableEnd = Math.min(MEASURE_DURATION_MS - TAIL_TRIM_MS, performance.now() - startTime);
+    const windowStart = RAMP_UP_TRIM_MS;
+    if (usableEnd <= windowStart) {
+        const totalS = (performance.now() - startTime) / 1000 || 0.001;
+        const speed = (totalBytes * 8 / totalS) / (1024 * 1024);
+        await sendProgress({ uploadSpeed: speed, status: 'Upload complete' });
+        return speed;
+    }
+    const speedMbps = speedFromWindow(samples, windowStart, usableEnd);
     await sendProgress({ uploadSpeed: speedMbps, status: 'Upload complete' });
     return speedMbps;
 }
@@ -266,8 +418,20 @@ async function runFullTest(): Promise<TestResults> {
         const baseUrl = await getServerUrl();
         await sendProgress({ status: results.status });
 
+        // IP family detect runs early and non-fatally
+        detectIpFamily(baseUrl).then(f => {
+            results.ipv4Ok = f.ipv4Ok;
+            results.ipv6Ok = f.ipv6Ok;
+        }).catch(() => { /* non-fatal */ });
+
         checkCancelled();
+        const loadedProbe = startLoadedPingProbe(baseUrl);
         results.downloadSpeed = await measureDownloadSpeed(baseUrl);
+        const loadedSamples = await loadedProbe.stop();
+
+        // DNS timing captured from the most recent resource entry to our server
+        results.dnsLookupMs = extractDnsMs(baseUrl);
+
         checkCancelled();
         results.uploadSpeed = await measureUploadSpeed(baseUrl);
         checkCancelled();
@@ -279,6 +443,15 @@ async function runFullTest(): Promise<TestResults> {
         results.ping = pingResult.ping;
         results.jitter = pingResult.jitter;
         results.packetLoss = pingResult.packetLoss;
+
+        // Bufferbloat = loaded ping median minus idle ping. Graded A-F.
+        if (loadedSamples.length > 0 && results.ping !== undefined) {
+            const sorted = [...loadedSamples].sort((a, b) => a - b);
+            const median = sorted[Math.floor(sorted.length / 2)];
+            const delta = Math.max(0, median - results.ping);
+            results.bufferbloatDelta = delta;
+            results.bufferbloatGrade = gradeBufferbloat(delta);
+        }
 
         results.status = 'Test complete';
 
@@ -305,6 +478,62 @@ async function runFullTest(): Promise<TestResults> {
     return results;
 }
 
+// --- Scheduled background tests ---
+async function rescheduleTestsFromPrefs(): Promise<void> {
+    try {
+        const { scheduleMinutes } = await chrome.storage.sync.get('scheduleMinutes');
+        const minutes = Number(scheduleMinutes) || 0;
+        await chrome.alarms.clear(SCHEDULE_ALARM_NAME);
+        if (minutes > 0) {
+            chrome.alarms.create(SCHEDULE_ALARM_NAME, { periodInMinutes: minutes, delayInMinutes: minutes });
+        }
+    } catch (e) {
+        console.error('Reschedule failed:', e);
+    }
+}
+
+function qualityGrade(dl?: number, ul?: number, ping?: number): 'excellent' | 'good' | 'fair' | 'poor' | null {
+    if (dl === undefined || ul === undefined || ping === undefined) return null;
+    if (dl >= 50 && ul >= 20 && ping < 30) return 'excellent';
+    if (dl >= 20 && ul >= 10 && ping < 60) return 'good';
+    if (dl >= 5 && ul >= 2 && ping < 150) return 'fair';
+    return 'poor';
+}
+
+async function maybeNotifyQualityDrop(current: TestResults): Promise<void> {
+    try {
+        const { notifyOnDrop } = await chrome.storage.sync.get('notifyOnDrop');
+        if (!notifyOnDrop) return;
+        const grade = qualityGrade(current.downloadSpeed, current.uploadSpeed, current.ping);
+        if (grade !== 'poor') return;
+        await chrome.notifications.create(QUALITY_DROP_NOTIFICATION_ID, {
+            type: 'basic',
+            iconUrl: chrome.runtime.getURL('images/icons128.png'),
+            title: 'MeterX — connection quality dropped',
+            message: `Poor: ${(current.downloadSpeed ?? 0).toFixed(1)} Mbps down, ping ${(current.ping ?? 0).toFixed(0)}ms.`,
+            priority: 1,
+        });
+    } catch (e) {
+        console.error('Notify failed:', e);
+    }
+}
+
+chrome.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarm.name !== SCHEDULE_ALARM_NAME) return;
+    const result = await runFullTest();
+    if (result.status.startsWith('Test complete')) {
+        await maybeNotifyQualityDrop(result);
+    }
+});
+
+chrome.runtime.onInstalled.addListener(() => { rescheduleTestsFromPrefs(); });
+chrome.runtime.onStartup.addListener(() => { rescheduleTestsFromPrefs(); });
+
+// Side Panel — open on action click when popup disabled, plus available via API
+if (chrome.sidePanel?.setPanelBehavior) {
+    chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false }).catch(() => { /* old chrome */ });
+}
+
 chrome.runtime.onMessage.addListener(
     (message: { action: string; url?: string }, _sender: chrome.runtime.MessageSender, sendResponse: (response: unknown) => void) => {
         if (message.action === "startTest") {
@@ -325,6 +554,17 @@ chrome.runtime.onMessage.addListener(
         if (message.action === "getServerUrl") {
             getServerUrl().then(url => sendResponse({ url }));
             return true;
+        }
+        if (message.action === "rescheduleTests") {
+            rescheduleTestsFromPrefs().then(() => sendResponse({ success: true }));
+            return true;
+        }
+        if (message.action === "openSidePanel") {
+            if (chrome.sidePanel?.open && _sender.tab?.windowId !== undefined) {
+                chrome.sidePanel.open({ windowId: _sender.tab.windowId }).catch(() => { /* not supported */ });
+            }
+            sendResponse({ success: true });
+            return false;
         }
         if (message.action === "setServerUrl") {
             const url = message.url?.trim() || '';

--- a/packages/extension/src/chart.ts
+++ b/packages/extension/src/chart.ts
@@ -1,0 +1,72 @@
+/**
+ * Side-panel trend chart — inline SVG, no deps.
+ * Shows download (cyan), upload (purple), ping (green) on a shared time axis.
+ * @license AGPL-3.0
+ */
+
+import type { HistoryEntry } from '@meterx/shared';
+
+const W = 560;
+const H = 120;
+const PAD_L = 28;
+const PAD_R = 8;
+const PAD_T = 8;
+const PAD_B = 18;
+
+export function renderChart(el: HTMLElement, history: HistoryEntry[]): void {
+    const entries = history.slice(0, 60).reverse();
+    if (entries.length < 2) {
+        el.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:100%;color:var(--t3);font-size:11px">Run two tests to see the trend.</div>';
+        return;
+    }
+
+    const dl = entries.map(e => e.downloadSpeed ?? null);
+    const ul = entries.map(e => e.uploadSpeed ?? null);
+    const pi = entries.map(e => e.ping ?? null);
+    const times = entries.map(e => e.timestamp);
+
+    const speedMax = Math.max(1, ...dl.filter((v): v is number => v !== null), ...ul.filter((v): v is number => v !== null));
+    const pingMax = Math.max(1, ...pi.filter((v): v is number => v !== null));
+
+    const xStep = (W - PAD_L - PAD_R) / (entries.length - 1);
+    const xAt = (i: number) => PAD_L + i * xStep;
+    const yAtSpeed = (v: number) => PAD_T + (H - PAD_T - PAD_B) * (1 - v / speedMax);
+    const yAtPing  = (v: number) => PAD_T + (H - PAD_T - PAD_B) * (1 - v / pingMax);
+
+    const path = (vals: (number | null)[], mapY: (v: number) => number): string => {
+        let d = '';
+        let open = false;
+        vals.forEach((v, i) => {
+            if (v === null) { open = false; return; }
+            d += `${open ? 'L' : 'M'}${xAt(i).toFixed(1)},${mapY(v).toFixed(1)} `;
+            open = true;
+        });
+        return d.trim();
+    };
+
+    const dlPath = path(dl, yAtSpeed);
+    const ulPath = path(ul, yAtSpeed);
+    const piPath = path(pi, yAtPing);
+
+    const firstLabel = new Date(times[0]).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+    const lastLabel = new Date(times[times.length - 1]).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+
+    el.innerHTML = `
+      <svg width="100%" height="${H}" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img" aria-label="Network speed and ping trend">
+        <line x1="${PAD_L}" y1="${H - PAD_B}" x2="${W - PAD_R}" y2="${H - PAD_B}" stroke="rgba(255,255,255,0.06)"/>
+        <line x1="${PAD_L}" y1="${PAD_T}" x2="${PAD_L}" y2="${H - PAD_B}" stroke="rgba(255,255,255,0.06)"/>
+        <text x="${PAD_L - 4}" y="${PAD_T + 8}" text-anchor="end" fill="rgba(255,255,255,0.3)" font-size="8">${speedMax.toFixed(0)}</text>
+        <text x="${PAD_L - 4}" y="${H - PAD_B}" text-anchor="end" fill="rgba(255,255,255,0.3)" font-size="8">0</text>
+        <text x="${PAD_L}" y="${H - 4}" fill="rgba(255,255,255,0.3)" font-size="8">${firstLabel}</text>
+        <text x="${W - PAD_R}" y="${H - 4}" text-anchor="end" fill="rgba(255,255,255,0.3)" font-size="8">${lastLabel}</text>
+        <path d="${dlPath}" fill="none" stroke="#00c8ff" stroke-width="1.5"/>
+        <path d="${ulPath}" fill="none" stroke="#a855f7" stroke-width="1.5"/>
+        <path d="${piPath}" fill="none" stroke="#34d399" stroke-width="1" stroke-dasharray="2,2"/>
+        <g font-size="8" fill="rgba(255,255,255,0.55)">
+          <rect x="${W - 110}" y="${PAD_T}" width="8" height="2" fill="#00c8ff"/><text x="${W - 98}" y="${PAD_T + 4}">Down</text>
+          <rect x="${W - 70}"  y="${PAD_T}" width="8" height="2" fill="#a855f7"/><text x="${W - 58}" y="${PAD_T + 4}">Up</text>
+          <rect x="${W - 40}"  y="${PAD_T}" width="8" height="2" fill="#34d399"/><text x="${W - 28}" y="${PAD_T + 4}">Ping</text>
+        </g>
+      </svg>
+    `;
+}

--- a/packages/extension/src/export-data.ts
+++ b/packages/extension/src/export-data.ts
@@ -1,0 +1,72 @@
+/**
+ * JSON + CSV export for machine-readable workflows.
+ * @license AGPL-3.0
+ */
+
+import type { HistoryEntry } from '@meterx/shared';
+
+function triggerDownload(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 5000);
+}
+
+export function exportJson(history: HistoryEntry[]): void {
+    const payload = {
+        exportedAt: new Date().toISOString(),
+        tool: 'MeterX',
+        version: '2026.0.319-MR1.0',
+        count: history.length,
+        results: history.map(e => ({
+            timestamp: e.timestamp,
+            isoTime: new Date(e.timestamp).toISOString(),
+            downloadMbps: e.downloadSpeed,
+            uploadMbps: e.uploadSpeed,
+            pingMs: e.ping,
+            jitterMs: e.jitter,
+            packetLossPct: e.packetLoss,
+            bufferbloatDeltaMs: e.bufferbloatDelta,
+            bufferbloatGrade: e.bufferbloatGrade,
+            dnsLookupMs: e.dnsLookupMs,
+            ipv4Ok: e.ipv4Ok,
+            ipv6Ok: e.ipv6Ok,
+            edge: e.edge,
+        })),
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+    triggerDownload(blob, `meterx-export-${new Date().toLocaleDateString('en-CA')}.json`);
+}
+
+export function exportCsv(history: HistoryEntry[]): void {
+    const cols = ['timestamp', 'isoTime', 'downloadMbps', 'uploadMbps', 'pingMs', 'jitterMs', 'packetLossPct', 'bufferbloatDeltaMs', 'bufferbloatGrade', 'dnsLookupMs', 'ipv4Ok', 'ipv6Ok', 'edge'];
+    const rows = history.map(e => [
+        e.timestamp,
+        new Date(e.timestamp).toISOString(),
+        e.downloadSpeed ?? '',
+        e.uploadSpeed ?? '',
+        e.ping ?? '',
+        e.jitter ?? '',
+        e.packetLoss ?? '',
+        e.bufferbloatDelta ?? '',
+        e.bufferbloatGrade ?? '',
+        e.dnsLookupMs ?? '',
+        e.ipv4Ok ?? '',
+        e.ipv6Ok ?? '',
+        e.edge ?? '',
+    ]);
+    const csv = [cols.join(','), ...rows.map(r => r.map(escapeCsv).join(','))].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    triggerDownload(blob, `meterx-export-${new Date().toLocaleDateString('en-CA')}.csv`);
+}
+
+function escapeCsv(v: unknown): string {
+    if (v === null || v === undefined) return '';
+    const s = String(v);
+    if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+    return s;
+}

--- a/packages/extension/src/export-pdf.ts
+++ b/packages/extension/src/export-pdf.ts
@@ -1,0 +1,298 @@
+/**
+ * PDF report generation — heavy imports (html2canvas, jspdf) loaded on demand.
+ * @license AGPL-3.0
+ */
+
+import type { HistoryEntry } from '@meterx/shared';
+import { getQuality } from './quality';
+
+interface ConnInfo { type?: string; effectiveType?: string }
+
+export async function exportPdfReport(hist: HistoryEntry[]): Promise<void> {
+    if (hist.length === 0) throw new Error('No data to export');
+
+    const avg = (a: number[]) => a.length ? a.reduce((s, v) => s + v, 0) / a.length : 0;
+    const mn = (a: number[]) => a.length ? Math.min(...a) : 0;
+    const mx = (a: number[]) => a.length ? Math.max(...a) : 0;
+    const sd = (a: number[]) => { const m = avg(a); return Math.sqrt(avg(a.map(v => (v - m) ** 2))); };
+
+    const dlV = hist.filter(e => e.downloadSpeed !== undefined).map(e => e.downloadSpeed!);
+    const ulV = hist.filter(e => e.uploadSpeed !== undefined).map(e => e.uploadSpeed!);
+    const piV = hist.filter(e => e.ping !== undefined).map(e => e.ping!);
+    const jiV = hist.filter(e => e.jitter !== undefined).map(e => e.jitter!);
+    const loV = hist.filter(e => e.packetLoss !== undefined).map(e => e.packetLoss!);
+
+    const aDl = avg(dlV), aUl = avg(ulV), aPi = avg(piV), aJi = avg(jiV), aLo = avg(loV);
+    const qual = getQuality(aDl, aUl, aPi);
+    const cons = dlV.length > 1 ? Math.max(0, Math.min(100, 100 - (sd(dlV) / aDl) * 100)) : 100;
+    const consLabel = cons >= 85 ? 'Stable' : cons >= 70 ? 'Moderate' : cons >= 50 ? 'Unstable' : 'Very unstable';
+    const anomThresh = aDl * 0.5;
+    const anomCount = dlV.filter(v => v < anomThresh).length;
+    const halfIdx = Math.floor(dlV.length / 2);
+    const trendPct = avg(dlV.slice(halfIdx)) > 0 ? ((avg(dlV.slice(0, halfIdx)) - avg(dlV.slice(halfIdx))) / avg(dlV.slice(halfIdx))) * 100 : 0;
+    const trendLabel = Math.abs(trendPct) < 5 ? 'Stable' : trendPct > 0 ? `Improving (+${trendPct.toFixed(0)}%)` : `Declining (${trendPct.toFixed(0)}%)`;
+
+    const now = new Date();
+    const oldest = new Date(hist[hist.length - 1].timestamp);
+    const newest = new Date(hist[0].timestamp);
+    const spanMin = Math.floor((newest.getTime() - oldest.getTime()) / 60000);
+    const period = spanMin < 60 ? `${spanMin} min session` : spanMin < 1440 ? `${Math.floor(spanMin / 60)} hour session` : `${Math.floor(spanMin / 1440)} days`;
+
+    const qCol = qual.cls === 'excellent' ? '#34d399' : qual.cls === 'good' ? '#60a5fa' : qual.cls === 'fair' ? '#fbbf24' : '#f87171';
+    const consCol = cons >= 85 ? '#34d399' : cons >= 70 ? '#fbbf24' : '#f87171';
+    const trendCol = Math.abs(trendPct) < 5 ? '#8888a0' : trendPct > 0 ? '#34d399' : '#f87171';
+
+    const conn = (navigator as unknown as { connection?: ConnInfo }).connection;
+    const envParts: string[] = [];
+    if (conn?.type && conn.type !== 'unknown') envParts.push(`Connection: ${({ wifi: 'WiFi', ethernet: 'Ethernet', cellular: 'Cellular' } as Record<string, string>)[conn.type] || conn.type}`);
+    if (conn?.effectiveType) envParts.push(`Speed tier: ${conn.effectiveType.toUpperCase()}`);
+
+    const gamSub = aPi < 50 ? 'Competitive OK' : aPi < 100 ? 'Casual only' : 'Not recommended';
+    const ucData = [
+        { l: 'Video Calls', s: 'Zoom, Meet, Teams', sc: (aDl >= 5 && aUl >= 3 && aPi < 100 && aJi < 30) ? 'Good' : (aDl >= 2 && aUl >= 1) ? 'Moderate' : 'Poor' },
+        { l: '4K Streaming', s: 'Netflix, YouTube', sc: aDl >= 25 ? 'Good' : aDl >= 5 ? 'HD only' : 'Poor' },
+        { l: 'Gaming', s: gamSub, sc: (aPi < 50 && aJi < 20 && aLo < 1) ? 'Good' : aPi < 100 ? 'Moderate' : 'Poor' },
+        { l: 'Uploads', s: 'Cloud sync, files', sc: aUl >= 10 ? 'Good' : aUl >= 3 ? 'Moderate' : 'Poor' },
+    ];
+
+    const ucColor = (sc: string) => sc === 'Good' ? '#34d399' : sc === 'Poor' ? '#f87171' : '#fbbf24';
+    const ucBg = (sc: string) => sc === 'Good' ? '#0d1f17' : sc === 'Poor' ? '#1f0d0d' : '#1f1a0d';
+
+    const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>MeterX Network Health Report</title>
+<style>
+@media print {
+  @page { size: A4; margin: 12mm; }
+  body { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #0c0c14; color: #e8e8e8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; line-height: 1.5; padding: 32px; min-height: 100vh; }
+.accent-bar { height: 4px; background: linear-gradient(90deg, #00c8ff, #a855f7); border-radius: 2px; margin-bottom: 24px; }
+.header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 20px; }
+.header h1 { font-size: 22px; color: #00c8ff; font-weight: 700; }
+.header .meta { text-align: right; color: #555570; font-size: 10px; }
+.card { background: #151520; border: 1px solid #1e1e2e; border-radius: 10px; padding: 20px; margin-bottom: 16px; }
+.quality-hero { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+.quality-hero .qlabel { font-size: 36px; font-weight: 800; }
+.quality-hero .qsub { color: #8888a0; font-size: 12px; margin-top: 4px; }
+.quality-hero .right { text-align: right; font-size: 10px; line-height: 1.8; }
+.env { color: #555570; font-size: 10px; margin-bottom: 12px; }
+.divider { border: none; border-top: 1px solid #1e1e2e; margin: 16px 0; }
+.metrics { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 12px; }
+.metric-card { background: #151520; border: 1px solid #1e1e2e; border-radius: 8px; padding: 16px; }
+.metric-card .lbl { color: #555570; font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+.metric-card .val { font-size: 32px; font-weight: 800; line-height: 1.1; }
+.metric-card .unit { color: #8888a0; font-size: 12px; margin-top: 4px; }
+.metric-card .range { color: #555570; font-size: 9px; margin-top: 10px; padding-top: 8px; border-top: 1px solid #1e1e2e; }
+.sec-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px; }
+.sec-card { background: #151520; border: 1px solid #1e1e2e; border-radius: 8px; padding: 12px 16px; display: flex; justify-content: space-between; align-items: center; }
+.sec-card .lbl { color: #555570; font-size: 9px; text-transform: uppercase; }
+.sec-card .val { font-size: 16px; font-weight: 700; color: #e8e8e8; }
+.sec-card .range { color: #555570; font-size: 9px; }
+.sec-card .no-loss { color: #34d399; font-size: 9px; font-weight: 600; }
+h2 { font-size: 14px; font-weight: 700; margin-bottom: 12px; color: #e8e8e8; }
+.uc-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 16px; }
+.uc-card { border-radius: 8px; padding: 14px; border: 1px solid; }
+.uc-card .name { font-size: 9px; color: #8888a0; margin-bottom: 6px; }
+.uc-card .score { font-size: 16px; font-weight: 700; }
+.uc-card .sub { font-size: 8px; color: #555570; margin-top: 6px; }
+table { width: 100%; border-collapse: collapse; font-size: 10px; }
+thead th { background: #16162a; color: #00c8ff; font-size: 8px; font-weight: 700; letter-spacing: 0.04em; padding: 8px 10px; text-align: left; }
+thead th:first-child { border-radius: 6px 0 0 6px; }
+thead th:last-child { border-radius: 0 6px 6px 0; }
+tbody tr { border-bottom: 1px solid #1a1a2a; }
+tbody tr:nth-child(even) { background: #10101c; }
+tbody tr.anomaly { background: #140a0a; }
+tbody tr.anomaly td:first-child { border-left: 2px solid #f87171; padding-left: 8px; }
+tbody td { padding: 6px 10px; color: #8888a0; }
+.dl { color: #00c8ff; } .ul { color: #a855f7; } .pi { color: #34d399; }
+.anom-dl { color: #f87171 !important; } .anom-dt { color: #ff6b6b !important; }
+.badge-anom { background: #f87171; color: #fff; font-size: 8px; font-weight: 700; padding: 2px 8px; border-radius: 4px; display: inline-block; }
+.watermark { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(35deg); font-size: 100px; font-weight: 800; color: rgba(255,255,255,0.015); pointer-events: none; z-index: -1; letter-spacing: 0.1em; }
+</style></head><body>
+<div class="watermark">MeterX</div>
+<div class="accent-bar"></div>
+
+<div class="header">
+  <h1>Network Health Report</h1>
+  <div class="meta">
+    ${now.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}, ${now.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}<br>
+    ${period} &middot; ${hist.length} tests
+  </div>
+</div>
+
+<div class="card">
+  <div class="quality-hero">
+    <div>
+      <div class="qlabel" style="color:${qCol}">${qual.label}</div>
+      <div class="qsub">Network Quality</div>
+    </div>
+    <div class="right">
+      <div style="color:${consCol};font-weight:700">${cons.toFixed(0)}% stable (${consLabel})</div>
+      <div style="color:#555570">Based on download speed variation</div>
+      <div style="color:${trendCol}">Trend: ${trendLabel}</div>
+      ${anomCount > 0
+        ? `<div style="color:#f87171;font-weight:700">${anomCount} anomal${anomCount === 1 ? 'y' : 'ies'} &mdash; DL dropped below ${anomThresh.toFixed(0)} Mbps</div>`
+        : '<div style="color:#34d399">No anomalies detected</div>'}
+    </div>
+  </div>
+</div>
+
+${envParts.length > 0 ? `<div class="env">${envParts.join(' &middot; ')}</div>` : ''}
+
+<hr class="divider">
+<div class="metrics">
+  ${[{ l: 'Download', a: aDl, lo: mn(dlV), hi: mx(dlV), u: 'Mbps', c: '#00c8ff' },
+       { l: 'Upload', a: aUl, lo: mn(ulV), hi: mx(ulV), u: 'Mbps', c: '#a855f7' },
+       { l: 'Ping', a: aPi, lo: mn(piV), hi: mx(piV), u: 'ms', c: '#34d399' }]
+        .map(m => `<div class="metric-card">
+      <div class="lbl">${m.l}</div>
+      <div class="val" style="color:${m.c}">${m.a.toFixed(1)}</div>
+      <div class="unit">${m.u}</div>
+      <div class="range">Range: ${m.lo.toFixed(1)} &ndash; ${m.hi.toFixed(1)}</div>
+    </div>`).join('')}
+</div>
+
+<div class="sec-metrics">
+  <div class="sec-card">
+    <div><div class="lbl">Jitter</div><div class="val">${aJi.toFixed(1)} ms</div></div>
+    <div class="range">Range: ${mn(jiV).toFixed(1)} &ndash; ${mx(jiV).toFixed(1)}</div>
+  </div>
+  <div class="sec-card">
+    <div><div class="lbl">Packet Loss</div><div class="val">${aLo.toFixed(1)} %</div></div>
+    ${mn(loV) === mx(loV) && aLo === 0 ? '<div class="no-loss">No loss detected</div>' : `<div class="range">Range: ${mn(loV).toFixed(1)} &ndash; ${mx(loV).toFixed(1)}</div>`}
+  </div>
+</div>
+
+<hr class="divider">
+<h2>Use-Case Assessment</h2>
+<div class="uc-grid">
+  ${ucData.map(c => `<div class="uc-card" style="background:${ucBg(c.sc)};border-color:${ucColor(c.sc)}">
+    <div class="name">${c.l}</div>
+    <div class="score" style="color:${ucColor(c.sc)}">${c.sc}</div>
+    <div class="sub">${c.s}</div>
+  </div>`).join('')}
+</div>
+
+<hr class="divider">
+<h2>Test History</h2>
+<table>
+  <thead><tr><th>Date / Time</th><th>DL (Mbps)</th><th>UL (Mbps)</th><th>Ping (ms)</th><th>Jitter (ms)</th><th>Loss (%)</th><th></th></tr></thead>
+  <tbody>
+    ${hist.map(e => {
+        const d = new Date(e.timestamp);
+        const dt = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+        const isA = e.downloadSpeed !== undefined && e.downloadSpeed < anomThresh;
+        return `<tr class="${isA ? 'anomaly' : ''}">
+      <td class="${isA ? 'anom-dt' : ''}">${dt}</td>
+      <td class="${isA ? 'anom-dl' : 'dl'}">${e.downloadSpeed !== undefined ? e.downloadSpeed.toFixed(1) : '-'}</td>
+      <td class="ul">${e.uploadSpeed !== undefined ? e.uploadSpeed.toFixed(1) : '-'}</td>
+      <td class="pi">${e.ping !== undefined ? e.ping.toFixed(1) : '-'}</td>
+      <td>${e.jitter !== undefined ? e.jitter.toFixed(1) : '-'}</td>
+      <td>${e.packetLoss !== undefined ? e.packetLoss.toFixed(0) : '-'}</td>
+      <td>${isA ? '<span class="badge-anom">ANOMALY</span>' : ''}</td>
+    </tr>`;
+    }).join('')}
+  </tbody>
+</table>
+
+</body></html>`;
+
+    const container = document.createElement('div');
+    container.style.cssText = 'position:fixed;left:-9999px;top:0;width:794px;visibility:visible;';
+    container.innerHTML = html.replace(/<!DOCTYPE html>[\s\S]*?<body[^>]*>/, '').replace(/<\/body>[\s\S]*/, '');
+
+    const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/);
+    if (styleMatch) {
+        const styleEl = document.createElement('style');
+        styleEl.textContent = styleMatch[1];
+        container.prepend(styleEl);
+    }
+    container.style.background = '#0c0c14';
+    container.style.padding = '30px 40px';
+    container.style.fontFamily = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
+    container.style.fontSize = '11px';
+    container.style.lineHeight = '1.5';
+    container.style.color = '#e8e8e8';
+
+    document.body.appendChild(container);
+
+    try {
+        const { default: html2canvas } = await import('html2canvas');
+        const { jsPDF } = await import('jspdf');
+
+        const canvas = await html2canvas(container, {
+            backgroundColor: '#0c0c14',
+            scale: 2,
+            useCORS: true,
+            logging: false,
+            allowTaint: true,
+            foreignObjectRendering: false,
+        });
+
+        const pdfW = 210, pdfH = 297, margin = 8;
+        const contentW = pdfW - margin * 2;
+        const footerH = 12, contHeaderH = 10;
+        const page1ContentH = pdfH - margin * 2 - footerH;
+        const pageNContentH = pdfH - margin * 2 - footerH - contHeaderH;
+        const scaleFactor = canvas.width / contentW;
+        const slice1H = page1ContentH * scaleFactor;
+        const sliceNH = pageNContentH * scaleFactor;
+
+        let remaining = canvas.height - slice1H;
+        let totalPages = 1;
+        while (remaining > 0) { totalPages++; remaining -= sliceNH; }
+
+        const doc = new jsPDF('p', 'mm', 'a4');
+        let srcOffset = 0;
+        for (let p = 0; p < totalPages; p++) {
+            if (p > 0) doc.addPage();
+            doc.setFillColor('#0c0c14');
+            doc.rect(0, 0, pdfW, pdfH, 'F');
+
+            const isFirst = p === 0;
+            const maxSlice = isFirst ? slice1H : sliceNH;
+            const topOffset = isFirst ? margin : margin + contHeaderH;
+            const srcH = Math.min(maxSlice, canvas.height - srcOffset);
+            const destH = srcH / scaleFactor;
+
+            const pageCanvas = document.createElement('canvas');
+            pageCanvas.width = canvas.width;
+            pageCanvas.height = srcH;
+            const ctx = pageCanvas.getContext('2d')!;
+            ctx.fillStyle = '#0c0c14';
+            ctx.fillRect(0, 0, pageCanvas.width, pageCanvas.height);
+            ctx.drawImage(canvas, 0, srcOffset, canvas.width, srcH, 0, 0, canvas.width, srcH);
+
+            doc.addImage(
+                pageCanvas.toDataURL('image/png'),
+                'PNG', margin, topOffset, contentW, destH,
+                undefined, 'FAST'
+            );
+            srcOffset += srcH;
+        }
+
+        const footerY = pdfH - margin - 4;
+        for (let p = 1; p <= totalPages; p++) {
+            doc.setPage(p);
+            doc.setDrawColor('#1e1e2e');
+            doc.line(margin, footerY - 4, pdfW - margin, footerY - 4);
+            doc.setFontSize(7);
+            doc.setTextColor('#555570');
+            doc.text('github.com/ajithakdev/meterx-server  |  v2026.0.319  |  AGPL-3.0', pdfW / 2, footerY, { align: 'center' });
+            doc.setTextColor('#8888a0');
+            doc.text(`${p} / ${totalPages}`, pdfW - margin, footerY, { align: 'right' });
+            if (p > 1) {
+                doc.setFontSize(9);
+                doc.setFont('helvetica', 'bold');
+                doc.setTextColor('#e8e8e8');
+                doc.text('Test History (continued)', margin, margin + 6);
+                doc.setFont('helvetica', 'normal');
+            }
+        }
+
+        doc.save(`MeterX-Report-${now.toLocaleDateString('en-CA')}.pdf`);
+    } finally {
+        document.body.removeChild(container);
+    }
+}

--- a/packages/extension/src/format.test.ts
+++ b/packages/extension/src/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { fmt, getTimeAgo } from './format';
+
+describe('fmt', () => {
+    it('formats a number with decimals', () => {
+        expect(fmt(3.14159, 2)).toBe('3.14');
+    });
+    it('returns -- for undefined', () => {
+        expect(fmt(undefined, 1)).toBe('--');
+    });
+    it('handles zero', () => {
+        expect(fmt(0, 1)).toBe('0.0');
+    });
+});
+
+describe('getTimeAgo', () => {
+    it('says "just now" for recent', () => {
+        expect(getTimeAgo(new Date(Date.now() - 5000))).toBe('just now');
+    });
+    it('formats minutes', () => {
+        expect(getTimeAgo(new Date(Date.now() - 5 * 60 * 1000))).toBe('5m ago');
+    });
+    it('formats hours', () => {
+        expect(getTimeAgo(new Date(Date.now() - 3 * 60 * 60 * 1000))).toBe('3h ago');
+    });
+    it('formats days', () => {
+        expect(getTimeAgo(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000))).toBe('2d ago');
+    });
+});

--- a/packages/extension/src/format.ts
+++ b/packages/extension/src/format.ts
@@ -1,0 +1,19 @@
+/**
+ * Tiny formatting helpers
+ * @license AGPL-3.0
+ */
+
+export function fmt(v: number | undefined, d: number): string {
+    return v !== undefined ? v.toFixed(d) : '--';
+}
+
+export function getTimeAgo(date: Date): string {
+    const diff = Date.now() - date.getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+}

--- a/packages/extension/src/history.ts
+++ b/packages/extension/src/history.ts
@@ -1,0 +1,49 @@
+/**
+ * History storage + rendering
+ * @license AGPL-3.0
+ */
+
+/// <reference types="chrome" />
+
+import type { HistoryEntry } from '@meterx/shared';
+import { fmt } from './format';
+import { getQualityClass } from './quality';
+
+export const MAX_HISTORY = 200;
+export const HISTORY_DISPLAY = 7;
+
+export async function saveHistory(entry: HistoryEntry): Promise<void> {
+    const result = await chrome.storage.local.get('history');
+    const history: HistoryEntry[] = result.history || [];
+    history.unshift(entry);
+    if (history.length > MAX_HISTORY) history.length = MAX_HISTORY;
+    await chrome.storage.local.set({ history });
+}
+
+export async function loadHistory(limit = HISTORY_DISPLAY): Promise<HistoryEntry[]> {
+    const result = await chrome.storage.local.get('history');
+    return (result.history || []).slice(0, limit);
+}
+
+export async function loadAllHistory(): Promise<HistoryEntry[]> {
+    const result = await chrome.storage.local.get('history');
+    return result.history || [];
+}
+
+export function renderHistory(list: HTMLElement, entries: HistoryEntry[]): void {
+    if (entries.length === 0) {
+        list.innerHTML = '<div class="history-item" style="justify-content:center;color:var(--t3)">No tests yet</div>';
+        return;
+    }
+    list.innerHTML = entries.map(e => {
+        const d = new Date(e.timestamp);
+        const t = `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}`;
+        const dl = fmt(e.downloadSpeed, 1);
+        const ul = fmt(e.uploadSpeed, 1);
+        const qClass = getQualityClass(e.downloadSpeed, e.uploadSpeed, e.ping);
+        return `<div class="history-item">
+            <span class="h-left"><span class="quality-dot ${qClass}"></span><span class="time">${t}</span></span>
+            <span class="speeds"><span class="dl">${dl}</span><span class="ul">${ul}</span></span>
+        </div>`;
+    }).join('');
+}

--- a/packages/extension/src/isp.ts
+++ b/packages/extension/src/isp.ts
@@ -1,0 +1,64 @@
+/**
+ * ISP advertised-plan comparison.
+ * Stores user's plan in chrome.storage.sync. Renders delivered % vs paid.
+ * @license AGPL-3.0
+ */
+
+/// <reference types="chrome" />
+
+import type { IspPlan, HistoryEntry } from '@meterx/shared';
+
+const KEY = 'ispPlan';
+
+export async function loadIspPlan(): Promise<IspPlan | null> {
+    const r = await chrome.storage.sync.get(KEY);
+    return (r[KEY] as IspPlan | undefined) ?? null;
+}
+
+export async function saveIspPlan(plan: IspPlan | null): Promise<void> {
+    if (plan === null) {
+        await chrome.storage.sync.remove(KEY);
+    } else {
+        await chrome.storage.sync.set({ [KEY]: plan });
+    }
+}
+
+export function renderIspComparison(el: HTMLElement, last: HistoryEntry | undefined, plan: IspPlan | null): void {
+    if (!plan) { el.classList.add('hidden'); return; }
+    if (!last || last.downloadSpeed === undefined) { el.classList.add('hidden'); return; }
+
+    const dlPct = plan.downloadMbps > 0 ? (last.downloadSpeed / plan.downloadMbps) * 100 : 0;
+    const ulPct = plan.uploadMbps > 0 && last.uploadSpeed !== undefined ? (last.uploadSpeed / plan.uploadMbps) * 100 : 0;
+
+    const dlCls = cls(dlPct);
+    const ulCls = cls(ulPct);
+
+    el.classList.remove('hidden');
+    el.innerHTML = `
+      <div class="isp-head">
+        <span class="isp-label">vs plan${plan.providerName ? ` (${escapeHtml(plan.providerName)})` : ''}</span>
+        <span class="isp-plan">${plan.downloadMbps}↓ / ${plan.uploadMbps}↑ Mbps</span>
+      </div>
+      <div class="isp-bars">
+        <div class="isp-row ${dlCls}">
+          <span class="isp-k">Download</span>
+          <span class="isp-v">${dlPct.toFixed(0)}% of paid</span>
+        </div>
+        ${last.uploadSpeed !== undefined ? `
+        <div class="isp-row ${ulCls}">
+          <span class="isp-k">Upload</span>
+          <span class="isp-v">${ulPct.toFixed(0)}% of paid</span>
+        </div>` : ''}
+      </div>
+    `;
+}
+
+function cls(pct: number): string {
+    if (pct >= 80) return 'ok';
+    if (pct >= 50) return 'warn';
+    return 'bad';
+}
+
+function escapeHtml(s: string): string {
+    return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}

--- a/packages/extension/src/options.ts
+++ b/packages/extension/src/options.ts
@@ -6,7 +6,12 @@
 
 /// <reference types="chrome" />
 
+import type { IspPlan } from '@meterx/shared';
+
 const DEFAULT_URL = 'https://meterx-speedtest.meterx-ajithakdev.workers.dev';
+const ISP_KEY = 'ispPlan';
+const SCHEDULE_KEY = 'scheduleMinutes';
+const NOTIFY_KEY = 'notifyOnDrop';
 
 // IATA code to city name mapping for common Cloudflare PoPs
 const EDGE_NAMES: Record<string, string> = {
@@ -33,8 +38,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     const radios = document.querySelectorAll<HTMLInputElement>('input[name="serverType"]');
     const radioOptions = document.querySelectorAll('.radio-option');
 
+    const ispDown = document.getElementById('ispDown') as HTMLInputElement | null;
+    const ispUp = document.getElementById('ispUp') as HTMLInputElement | null;
+    const ispProvider = document.getElementById('ispProvider') as HTMLInputElement | null;
+    const ispClearBtn = document.getElementById('ispClearBtn') as HTMLButtonElement | null;
+    const scheduleRadios = document.querySelectorAll<HTMLInputElement>('input[name="schedule"]');
+    const notifyCheckbox = document.getElementById('notifyOnDrop') as HTMLInputElement | null;
+
     // Close button
     closeBtn.addEventListener('click', () => window.close());
+
+    // Load ISP plan + schedule prefs
+    const stored = await chrome.storage.sync.get([ISP_KEY, SCHEDULE_KEY, NOTIFY_KEY]);
+    const plan = stored[ISP_KEY] as IspPlan | undefined;
+    if (plan && ispDown && ispUp && ispProvider) {
+        ispDown.value = String(plan.downloadMbps);
+        ispUp.value = String(plan.uploadMbps);
+        ispProvider.value = plan.providerName ?? '';
+    }
+    const scheduleMinutes: number = stored[SCHEDULE_KEY] ?? 0;
+    scheduleRadios.forEach(r => { r.checked = Number(r.value) === scheduleMinutes || (r.value === 'off' && scheduleMinutes === 0); });
+    if (notifyCheckbox) notifyCheckbox.checked = !!stored[NOTIFY_KEY];
+
+    if (ispClearBtn) {
+        ispClearBtn.addEventListener('click', async () => {
+            if (ispDown) ispDown.value = '';
+            if (ispUp) ispUp.value = '';
+            if (ispProvider) ispProvider.value = '';
+            await chrome.storage.sync.remove(ISP_KEY);
+        });
+    }
 
     // Load current setting
     const result = await chrome.storage.sync.get('serverUrl');
@@ -64,6 +97,21 @@ document.addEventListener('DOMContentLoaded', async () => {
             updateRadioStyles();
         });
     });
+
+    // Validate server URL matches manifest-declared optional_host_permissions patterns.
+    // Why: manifest now scopes http:// to localhost/127.0.0.1/*.local only. Reject anything else
+    // before chrome.permissions.request to surface a clear error instead of a silent denial.
+    function validateServerUrl(raw: string): string | null {
+        let parsed: URL;
+        try { parsed = new URL(raw); } catch { return 'Invalid URL format'; }
+        if (parsed.protocol === 'https:') return null;
+        if (parsed.protocol === 'http:') {
+            const host = parsed.hostname;
+            if (host === 'localhost' || host === '127.0.0.1' || host.endsWith('.local')) return null;
+            return 'Plain http:// only allowed for localhost, 127.0.0.1, or *.local. Use https for remote servers.';
+        }
+        return 'URL must use https:// (or http:// for localhost)';
+    }
 
     // Get active server URL
     function getActiveUrl(): string {
@@ -155,6 +203,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 testStatus.className = 'test-status error';
                 return;
             }
+            const validationError = validateServerUrl(url);
+            if (validationError) {
+                testStatus.textContent = validationError;
+                testStatus.className = 'test-status error';
+                return;
+            }
             // Request host permission for custom URL
             try {
                 const origin = new URL(url).origin + '/*';
@@ -173,6 +227,28 @@ document.addEventListener('DOMContentLoaded', async () => {
         } else {
             await chrome.storage.sync.remove('serverUrl');
         }
+
+        // Save ISP plan
+        if (ispDown && ispUp) {
+            const dl = Number(ispDown.value);
+            const ul = Number(ispUp.value);
+            if (dl > 0 || ul > 0) {
+                const planToSave: IspPlan = {
+                    downloadMbps: dl > 0 ? dl : 0,
+                    uploadMbps: ul > 0 ? ul : 0,
+                    providerName: ispProvider?.value.trim() || undefined,
+                };
+                await chrome.storage.sync.set({ [ISP_KEY]: planToSave });
+            } else {
+                await chrome.storage.sync.remove(ISP_KEY);
+            }
+        }
+
+        // Save schedule
+        const selectedSchedule = Array.from(scheduleRadios).find(r => r.checked);
+        const minutes = selectedSchedule && selectedSchedule.value !== 'off' ? Number(selectedSchedule.value) : 0;
+        await chrome.storage.sync.set({ [SCHEDULE_KEY]: minutes, [NOTIFY_KEY]: !!notifyCheckbox?.checked });
+        chrome.runtime.sendMessage({ action: 'rescheduleTests' });
 
         // Re-check status with new URL
         checkStatus();

--- a/packages/extension/src/popup.ts
+++ b/packages/extension/src/popup.ts
@@ -1,23 +1,23 @@
 /**
- * MeterX Popup UI
+ * MeterX Popup UI — orchestrator. Heavy logic lives in sibling modules.
  * @author ajithakdev (https://github.com/ajithakdev)
  * @license AGPL-3.0
- * @version 2026.0.319-MR1.0
  */
 
 /// <reference types="chrome" />
 
-interface HistoryEntry {
-    timestamp: number;
-    downloadSpeed?: number;
-    uploadSpeed?: number;
-    ping?: number;
-    jitter?: number;
-    packetLoss?: number;
-}
+import type { HistoryEntry } from '@meterx/shared';
+import { fmt, getTimeAgo } from './format';
+import { getQuality, scoreUseCases } from './quality';
+import { loadHistory, loadAllHistory, saveHistory } from './history';
+import { renderHistory } from './history';
+import { exportPdfReport } from './export-pdf';
+import { exportJson, exportCsv } from './export-data';
+import { buildShareUrl } from './share';
+import { renderSparkline } from './sparkline';
+import { bindTooltips } from './tooltips';
+import { loadIspPlan, renderIspComparison } from './isp';
 
-const MAX_HISTORY = 200; // ~30 days if testing ~7x/day
-const HISTORY_DISPLAY = 7;
 const MAX_SPEED = 200;
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -52,24 +52,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const ucGaming = $('uc-gaming');
     const ucUpload = $('uc-upload');
     const exportBtn = $('exportBtn') as HTMLButtonElement;
+    const exportMenu = document.getElementById('exportMenu') as HTMLElement | null;
+    const exportBackdrop = document.getElementById('exportBackdrop') as HTMLElement | null;
     const closeBtn = $('closeBtn') as HTMLButtonElement;
-
     const settingsBtn = $('settingsBtn') as HTMLButtonElement;
+    const shareBtn = document.getElementById('shareBtn') as HTMLButtonElement | null;
+    const sparkEl = document.getElementById('sparkline') as HTMLElement | null;
+    const ispCompareEl = document.getElementById('ispCompare') as HTMLElement | null;
 
-    // --- Close button ---
     closeBtn.addEventListener('click', () => window.close());
-
-    // --- Settings button ---
-    settingsBtn.addEventListener('click', () => {
-        chrome.runtime.openOptionsPage();
-    });
+    settingsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());
+    bindTooltips(document);
 
     const segments = {
         download: $('seg-download'),
         upload: $('seg-upload'),
         ping: $('seg-ping'),
     };
-
     const lineFills = {
         'dl-ul': $('line-dl-ul'),
         'ul-ping': $('line-ul-ping'),
@@ -84,15 +83,11 @@ document.addEventListener('DOMContentLoaded', () => {
         function tick(now: number) {
             const elapsed = now - startTime;
             const progress = Math.min(elapsed / duration, 1);
-            // ease-out
             const eased = 1 - Math.pow(1 - progress, 3);
             const current = start + (target - start) * eased;
             heroSpeed.textContent = current.toFixed(1);
-            if (progress < 1) {
-                countAnim = requestAnimationFrame(tick);
-            } else {
-                countAnim = null;
-            }
+            if (progress < 1) countAnim = requestAnimationFrame(tick);
+            else countAnim = null;
         }
         countAnim = requestAnimationFrame(tick);
     }
@@ -100,10 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function setBar(el: HTMLElement, speed: number): void {
         const pct = Math.min((speed / MAX_SPEED) * 100, 100);
         el.style.width = pct + '%';
-        // Add glow when bar has meaningful width
-        if (pct > 5) {
-            el.classList.add('glow');
-        }
+        if (pct > 5) el.classList.add('glow');
     }
 
     function setHero(value: number, label: string): void {
@@ -124,53 +116,22 @@ document.addEventListener('DOMContentLoaded', () => {
             segments[seg].classList.toggle('active', i === idx);
             segments[seg].classList.toggle('done', i < idx);
         });
-        // Animate connecting lines: fill the line before the active segment
         lineFills['dl-ul'].style.width = idx >= 1 ? '100%' : '0%';
         lineFills['ul-ping'].style.width = idx >= 2 ? '100%' : '0%';
-        // Pulse the active bar icon
         dlIcon.classList.toggle('active-pulse', phase === 'download');
         ulIcon.classList.toggle('active-pulse', phase === 'upload');
     }
 
-    function getQuality(dl: number, ul: number, ping: number): { label: string; cls: string } {
-        if (dl >= 50 && ul >= 20 && ping < 30) return { label: 'Excellent', cls: 'excellent' };
-        if (dl >= 20 && ul >= 10 && ping < 60) return { label: 'Good', cls: 'good' };
-        if (dl >= 5 && ul >= 2 && ping < 150) return { label: 'Fair', cls: 'fair' };
-        return { label: 'Poor', cls: 'poor' };
-    }
-
-    function getQualityClass(dl?: number, ul?: number, ping?: number): string {
-        if (dl === undefined || ul === undefined || ping === undefined) return 'q-fair';
-        const q = getQuality(dl, ul, ping);
-        return 'q-' + q.cls;
-    }
-
-    function scoreUseCases(dl?: number, ul?: number, ping?: number, jitter?: number, loss?: number): void {
+    function applyUseCases(dl?: number, ul?: number, ping?: number, jitter?: number, loss?: number): void {
         if (dl === undefined || ul === undefined || ping === undefined) {
             useCases.classList.add('hidden');
             return;
         }
-        const j = jitter ?? 999;
-        const l = loss ?? 100;
-
-        // Video Calls: DL>=5, UL>=3, ping<100, jitter<30
-        const calls = (dl >= 5 && ul >= 3 && ping < 100 && j < 30) ? 'good'
-            : (dl >= 2 && ul >= 1 && ping < 200) ? 'okay' : 'poor';
-
-        // Streaming: DL>=25 (4K), >=5 (HD)
-        const stream = dl >= 25 ? 'good' : dl >= 5 ? 'okay' : 'poor';
-
-        // Gaming: ping<50, jitter<20, loss<1%
-        const gaming = (ping < 50 && j < 20 && l < 1) ? 'good'
-            : (ping < 100 && j < 40 && l < 3) ? 'okay' : 'poor';
-
-        // Uploads: UL>=10
-        const upload = ul >= 10 ? 'good' : ul >= 3 ? 'okay' : 'poor';
-
-        ucCalls.className = `uc ${calls}`;
-        ucStream.className = `uc ${stream}`;
-        ucGaming.className = `uc ${gaming}`;
-        ucUpload.className = `uc ${upload}`;
+        const s = scoreUseCases(dl, ul, ping, jitter, loss);
+        ucCalls.className = `uc ${s.calls}`;
+        ucStream.className = `uc ${s.stream}`;
+        ucGaming.className = `uc ${s.gaming}`;
+        ucUpload.className = `uc ${s.upload}`;
         useCases.classList.remove('hidden');
     }
 
@@ -209,7 +170,6 @@ document.addEventListener('DOMContentLoaded', () => {
         lineFills['ul-ping'].style.width = '0%';
     }
 
-    // --- Offline ---
     function checkOnline(): void {
         if (!navigator.onLine) { startButton.disabled = true; statusEl.textContent = 'No connection'; }
     }
@@ -217,13 +177,20 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('offline', () => { startButton.disabled = true; statusEl.textContent = 'No connection'; });
     checkOnline();
 
-    // --- Load last result on startup ---
+    async function refreshAuxiliaryViews(): Promise<void> {
+        const all = await loadAllHistory();
+        if (sparkEl) renderSparkline(sparkEl, all);
+        if (ispCompareEl) {
+            const plan = await loadIspPlan();
+            renderIspComparison(ispCompareEl, all[0], plan);
+        }
+    }
+
+    // --- Last-result restore on popup open ---
     (async () => {
-        const result = await chrome.storage.local.get('history');
-        const history: HistoryEntry[] = result.history || [];
+        const history = await loadAllHistory();
         if (history.length > 0) {
             const last = history[0];
-            const fmt = (v: number | undefined, d: number) => v !== undefined ? v.toFixed(d) : '--';
             downloadSpeedEl.textContent = fmt(last.downloadSpeed, 1);
             uploadSpeedEl.textContent = fmt(last.uploadSpeed, 1);
             pingEl.textContent = fmt(last.ping, 1);
@@ -244,32 +211,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 const q = getQuality(last.downloadSpeed, last.uploadSpeed, last.ping);
                 qualityBadge.textContent = q.label;
                 qualityBadge.className = `badge ${q.cls}`;
-                scoreUseCases(last.downloadSpeed, last.uploadSpeed, last.ping, last.jitter, last.packetLoss);
+                applyUseCases(last.downloadSpeed, last.uploadSpeed, last.ping, last.jitter, last.packetLoss);
             }
-
-            const d = new Date(last.timestamp);
-            const timeAgo = getTimeAgo(d);
-            statusEl.textContent = `Last test: ${timeAgo}`;
+            statusEl.textContent = `Last test: ${getTimeAgo(new Date(last.timestamp))}`;
         }
+        await refreshAuxiliaryViews();
     })();
 
-    function getTimeAgo(date: Date): string {
-        const diff = Date.now() - date.getTime();
-        const mins = Math.floor(diff / 60000);
-        if (mins < 1) return 'just now';
-        if (mins < 60) return `${mins}m ago`;
-        const hours = Math.floor(mins / 60);
-        if (hours < 24) return `${hours}h ago`;
-        const days = Math.floor(hours / 24);
-        return `${days}d ago`;
-    }
-
-    // --- Start ---
     startButton.addEventListener('click', () => {
         resetUI();
         setTesting(true);
         statusEl.textContent = 'Initializing...';
-        chrome.runtime.sendMessage({ action: "startTest" }, (response) => {
+        chrome.runtime.sendMessage({ action: 'startTest' }, (response) => {
             if (chrome.runtime.lastError) {
                 statusEl.textContent = `Error: ${chrome.runtime.lastError.message}`;
                 setTesting(false);
@@ -277,16 +230,14 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // --- Cancel ---
     cancelButton.addEventListener('click', () => {
-        chrome.runtime.sendMessage({ action: "cancelTest" });
+        chrome.runtime.sendMessage({ action: 'cancelTest' });
         statusEl.textContent = 'Cancelled';
         setTesting(false);
     });
 
-    // --- Messages ---
     chrome.runtime.onMessage.addListener((message) => {
-        if (message.action === "testProgress") {
+        if (message.action === 'testProgress') {
             const data = message.data;
             if (data.status) {
                 statusEl.textContent = data.status;
@@ -312,9 +263,8 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (data.jitter !== undefined) jitterEl.textContent = data.jitter.toFixed(1);
             if (data.packetLoss !== undefined) packetLossEl.textContent = data.packetLoss.toFixed(0);
-        } else if (message.action === "testComplete") {
+        } else if (message.action === 'testComplete') {
             const data = message.data;
-            const fmt = (v: number | undefined, d: number) => v !== undefined ? v.toFixed(d) : '--';
             downloadSpeedEl.textContent = fmt(data.downloadSpeed, 1);
             uploadSpeedEl.textContent = fmt(data.uploadSpeed, 1);
             pingEl.textContent = fmt(data.ping, 1);
@@ -337,9 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 qualityBadge.textContent = q.label;
                 qualityBadge.className = `badge ${q.cls}`;
             }
-
-            // Use-case readiness
-            scoreUseCases(data.downloadSpeed, data.uploadSpeed, data.ping, data.jitter, data.packetLoss);
+            applyUseCases(data.downloadSpeed, data.uploadSpeed, data.ping, data.jitter, data.packetLoss);
 
             statusEl.textContent = data.status || 'Test complete';
             setTesting(false);
@@ -347,58 +295,33 @@ document.addEventListener('DOMContentLoaded', () => {
             lineFills['dl-ul'].style.width = '100%';
             lineFills['ul-ping'].style.width = '100%';
 
-            saveHistory({
+            const entry: HistoryEntry = {
                 timestamp: Date.now(),
                 downloadSpeed: data.downloadSpeed,
                 uploadSpeed: data.uploadSpeed,
                 ping: data.ping,
                 jitter: data.jitter,
                 packetLoss: data.packetLoss,
-            });
-        } else if (message.action === "testError") {
+                bufferbloatDelta: data.bufferbloatDelta,
+                bufferbloatGrade: data.bufferbloatGrade,
+                dnsLookupMs: data.dnsLookupMs,
+                ipv4Ok: data.ipv4Ok,
+                ipv6Ok: data.ipv6Ok,
+                edge: data.edge,
+            };
+            saveHistory(entry).then(refreshAuxiliaryViews);
+        } else if (message.action === 'testError') {
             statusEl.textContent = message.error || 'Test failed';
             setTesting(false);
         }
     });
-
-    // --- History ---
-    async function saveHistory(entry: HistoryEntry): Promise<void> {
-        const result = await chrome.storage.local.get('history');
-        const history: HistoryEntry[] = result.history || [];
-        history.unshift(entry);
-        if (history.length > MAX_HISTORY) history.length = MAX_HISTORY;
-        await chrome.storage.local.set({ history });
-    }
-
-    async function loadHistory(): Promise<HistoryEntry[]> {
-        const result = await chrome.storage.local.get('history');
-        return (result.history || []).slice(0, HISTORY_DISPLAY);
-    }
-
-    function renderHistory(entries: HistoryEntry[]): void {
-        if (entries.length === 0) {
-            historyList.innerHTML = '<div class="history-item" style="justify-content:center;color:var(--t3)">No tests yet</div>';
-            return;
-        }
-        historyList.innerHTML = entries.map(e => {
-            const d = new Date(e.timestamp);
-            const t = `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}`;
-            const dl = e.downloadSpeed !== undefined ? e.downloadSpeed.toFixed(1) : '--';
-            const ul = e.uploadSpeed !== undefined ? e.uploadSpeed.toFixed(1) : '--';
-            const qClass = getQualityClass(e.downloadSpeed, e.uploadSpeed, e.ping);
-            return `<div class="history-item">
-                <span class="h-left"><span class="quality-dot ${qClass}"></span><span class="time">${t}</span></span>
-                <span class="speeds"><span class="dl">${dl}</span><span class="ul">${ul}</span></span>
-            </div>`;
-        }).join('');
-    }
 
     let historyOpen = false;
     historyToggle.addEventListener('click', async () => {
         historyOpen = !historyOpen;
         if (historyOpen) {
             const entries = await loadHistory();
-            renderHistory(entries);
+            renderHistory(historyList, entries);
             historyList.classList.remove('hidden');
             historyLabel.textContent = 'Hide';
         } else {
@@ -407,311 +330,73 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // --- Report Export (HTML -> Print-to-PDF) ---
-    exportBtn.addEventListener('click', async () => {
-        const result = await chrome.storage.local.get('history');
-        const hist: HistoryEntry[] = result.history || [];
-        if (hist.length === 0) { statusEl.textContent = 'No data to export'; return; }
-
-        statusEl.textContent = 'Generating report...';
-
-        const avg = (a: number[]) => a.length ? a.reduce((s, v) => s + v, 0) / a.length : 0;
-        const mn = (a: number[]) => a.length ? Math.min(...a) : 0;
-        const mx = (a: number[]) => a.length ? Math.max(...a) : 0;
-        const sd = (a: number[]) => { const m = avg(a); return Math.sqrt(avg(a.map(v => (v - m) ** 2))); };
-
-        const dlV = hist.filter(e => e.downloadSpeed !== undefined).map(e => e.downloadSpeed!);
-        const ulV = hist.filter(e => e.uploadSpeed !== undefined).map(e => e.uploadSpeed!);
-        const piV = hist.filter(e => e.ping !== undefined).map(e => e.ping!);
-        const jiV = hist.filter(e => e.jitter !== undefined).map(e => e.jitter!);
-        const loV = hist.filter(e => e.packetLoss !== undefined).map(e => e.packetLoss!);
-
-        const aDl = avg(dlV), aUl = avg(ulV), aPi = avg(piV), aJi = avg(jiV), aLo = avg(loV);
-        const qual = getQuality(aDl, aUl, aPi);
-        const cons = dlV.length > 1 ? Math.max(0, Math.min(100, 100 - (sd(dlV) / aDl) * 100)) : 100;
-        const consLabel = cons >= 85 ? 'Stable' : cons >= 70 ? 'Moderate' : cons >= 50 ? 'Unstable' : 'Very unstable';
-        const anomThresh = aDl * 0.5;
-        const anomCount = dlV.filter(v => v < anomThresh).length;
-        const halfIdx = Math.floor(dlV.length / 2);
-        const trendPct = avg(dlV.slice(halfIdx)) > 0 ? ((avg(dlV.slice(0, halfIdx)) - avg(dlV.slice(halfIdx))) / avg(dlV.slice(halfIdx))) * 100 : 0;
-        const trendLabel = Math.abs(trendPct) < 5 ? 'Stable' : trendPct > 0 ? `Improving (+${trendPct.toFixed(0)}%)` : `Declining (${trendPct.toFixed(0)}%)`;
-
-        const now = new Date();
-        const oldest = new Date(hist[hist.length - 1].timestamp);
-        const newest = new Date(hist[0].timestamp);
-        const spanMin = Math.floor((newest.getTime() - oldest.getTime()) / 60000);
-        const period = spanMin < 60 ? `${spanMin} min session` : spanMin < 1440 ? `${Math.floor(spanMin / 60)} hour session` : `${Math.floor(spanMin / 1440)} days`;
-
-        const qCol = qual.cls === 'excellent' ? '#34d399' : qual.cls === 'good' ? '#60a5fa' : qual.cls === 'fair' ? '#fbbf24' : '#f87171';
-        const consCol = cons >= 85 ? '#34d399' : cons >= 70 ? '#fbbf24' : '#f87171';
-        const trendCol = Math.abs(trendPct) < 5 ? '#8888a0' : trendPct > 0 ? '#34d399' : '#f87171';
-
-        const conn = (navigator as unknown as { connection?: { type?: string; effectiveType?: string } }).connection;
-        const envParts: string[] = [];
-        if (conn?.type && conn.type !== 'unknown') envParts.push(`Connection: ${({ wifi: 'WiFi', ethernet: 'Ethernet', cellular: 'Cellular' } as Record<string, string>)[conn.type] || conn.type}`);
-        if (conn?.effectiveType) envParts.push(`Speed tier: ${conn.effectiveType.toUpperCase()}`);
-
-        const gamSub = aPi < 50 ? 'Competitive OK' : aPi < 100 ? 'Casual only' : 'Not recommended';
-        const ucData = [
-            { l: 'Video Calls', s: 'Zoom, Meet, Teams', sc: (aDl >= 5 && aUl >= 3 && aPi < 100 && aJi < 30) ? 'Good' : (aDl >= 2 && aUl >= 1) ? 'Moderate' : 'Poor' },
-            { l: '4K Streaming', s: 'Netflix, YouTube', sc: aDl >= 25 ? 'Good' : aDl >= 5 ? 'HD only' : 'Poor' },
-            { l: 'Gaming', s: gamSub, sc: (aPi < 50 && aJi < 20 && aLo < 1) ? 'Good' : aPi < 100 ? 'Moderate' : 'Poor' },
-            { l: 'Uploads', s: 'Cloud sync, files', sc: aUl >= 10 ? 'Good' : aUl >= 3 ? 'Moderate' : 'Poor' },
-        ];
-
-        const ucColor = (sc: string) => sc === 'Good' ? '#34d399' : sc === 'Poor' ? '#f87171' : '#fbbf24';
-        const ucBg = (sc: string) => sc === 'Good' ? '#0d1f17' : sc === 'Poor' ? '#1f0d0d' : '#1f1a0d';
-
-        const html = `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>MeterX Network Health Report</title>
-<style>
-@media print {
-  @page { size: A4; margin: 12mm; }
-  body { -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important; }
-}
-* { margin: 0; padding: 0; box-sizing: border-box; }
-body { background: #0c0c14; color: #e8e8e8; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 11px; line-height: 1.5; padding: 32px; min-height: 100vh; }
-.accent-bar { height: 4px; background: linear-gradient(90deg, #00c8ff, #a855f7); border-radius: 2px; margin-bottom: 24px; }
-.header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 20px; }
-.header h1 { font-size: 22px; color: #00c8ff; font-weight: 700; }
-.header .meta { text-align: right; color: #555570; font-size: 10px; }
-.card { background: #151520; border: 1px solid #1e1e2e; border-radius: 10px; padding: 20px; margin-bottom: 16px; }
-.quality-hero { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
-.quality-hero .qlabel { font-size: 36px; font-weight: 800; }
-.quality-hero .qsub { color: #8888a0; font-size: 12px; margin-top: 4px; }
-.quality-hero .right { text-align: right; font-size: 10px; line-height: 1.8; }
-.env { color: #555570; font-size: 10px; margin-bottom: 12px; }
-.divider { border: none; border-top: 1px solid #1e1e2e; margin: 16px 0; }
-.metrics { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 12px; }
-.metric-card { background: #151520; border: 1px solid #1e1e2e; border-radius: 8px; padding: 16px; }
-.metric-card .lbl { color: #555570; font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
-.metric-card .val { font-size: 32px; font-weight: 800; line-height: 1.1; }
-.metric-card .unit { color: #8888a0; font-size: 12px; margin-top: 4px; }
-.metric-card .range { color: #555570; font-size: 9px; margin-top: 10px; padding-top: 8px; border-top: 1px solid #1e1e2e; }
-.sec-metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px; }
-.sec-card { background: #151520; border: 1px solid #1e1e2e; border-radius: 8px; padding: 12px 16px; display: flex; justify-content: space-between; align-items: center; }
-.sec-card .lbl { color: #555570; font-size: 9px; text-transform: uppercase; }
-.sec-card .val { font-size: 16px; font-weight: 700; color: #e8e8e8; }
-.sec-card .range { color: #555570; font-size: 9px; }
-.sec-card .no-loss { color: #34d399; font-size: 9px; font-weight: 600; }
-h2 { font-size: 14px; font-weight: 700; margin-bottom: 12px; color: #e8e8e8; }
-.uc-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 16px; }
-.uc-card { border-radius: 8px; padding: 14px; border: 1px solid; }
-.uc-card .name { font-size: 9px; color: #8888a0; margin-bottom: 6px; }
-.uc-card .score { font-size: 16px; font-weight: 700; }
-.uc-card .sub { font-size: 8px; color: #555570; margin-top: 6px; }
-table { width: 100%; border-collapse: collapse; font-size: 10px; }
-thead th { background: #16162a; color: #00c8ff; font-size: 8px; font-weight: 700; letter-spacing: 0.04em; padding: 8px 10px; text-align: left; }
-thead th:first-child { border-radius: 6px 0 0 6px; }
-thead th:last-child { border-radius: 0 6px 6px 0; }
-tbody tr { border-bottom: 1px solid #1a1a2a; }
-tbody tr:nth-child(even) { background: #10101c; }
-tbody tr.anomaly { background: #140a0a; }
-tbody tr.anomaly td:first-child { border-left: 2px solid #f87171; padding-left: 8px; }
-tbody td { padding: 6px 10px; color: #8888a0; }
-.dl { color: #00c8ff; } .ul { color: #a855f7; } .pi { color: #34d399; }
-.anom-dl { color: #f87171 !important; } .anom-dt { color: #ff6b6b !important; }
-.badge-anom { background: #f87171; color: #fff; font-size: 8px; font-weight: 700; padding: 2px 8px; border-radius: 4px; display: inline-block; }
-.watermark { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) rotate(35deg); font-size: 100px; font-weight: 800; color: rgba(255,255,255,0.015); pointer-events: none; z-index: -1; letter-spacing: 0.1em; }
-</style></head><body>
-<div class="watermark">MeterX</div>
-<div class="accent-bar"></div>
-
-<div class="header">
-  <h1>Network Health Report</h1>
-  <div class="meta">
-    ${now.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}, ${now.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}<br>
-    ${period} &middot; ${hist.length} tests
-  </div>
-</div>
-
-<div class="card">
-  <div class="quality-hero">
-    <div>
-      <div class="qlabel" style="color:${qCol}">${qual.label}</div>
-      <div class="qsub">Network Quality</div>
-    </div>
-    <div class="right">
-      <div style="color:${consCol};font-weight:700">${cons.toFixed(0)}% stable (${consLabel})</div>
-      <div style="color:#555570">Based on download speed variation</div>
-      <div style="color:${trendCol}">Trend: ${trendLabel}</div>
-      ${anomCount > 0
-            ? `<div style="color:#f87171;font-weight:700">${anomCount} anomal${anomCount === 1 ? 'y' : 'ies'} &mdash; DL dropped below ${anomThresh.toFixed(0)} Mbps</div>`
-            : '<div style="color:#34d399">No anomalies detected</div>'}
-    </div>
-  </div>
-</div>
-
-${envParts.length > 0 ? `<div class="env">${envParts.join(' &middot; ')}</div>` : ''}
-
-<hr class="divider">
-<div class="metrics">
-  ${[{ l: 'Download', a: aDl, lo: mn(dlV), hi: mx(dlV), u: 'Mbps', c: '#00c8ff' },
-            { l: 'Upload', a: aUl, lo: mn(ulV), hi: mx(ulV), u: 'Mbps', c: '#a855f7' },
-            { l: 'Ping', a: aPi, lo: mn(piV), hi: mx(piV), u: 'ms', c: '#34d399' }]
-            .map(m => `<div class="metric-card">
-      <div class="lbl">${m.l}</div>
-      <div class="val" style="color:${m.c}">${m.a.toFixed(1)}</div>
-      <div class="unit">${m.u}</div>
-      <div class="range">Range: ${m.lo.toFixed(1)} &ndash; ${m.hi.toFixed(1)}</div>
-    </div>`).join('')}
-</div>
-
-<div class="sec-metrics">
-  <div class="sec-card">
-    <div><div class="lbl">Jitter</div><div class="val">${aJi.toFixed(1)} ms</div></div>
-    <div class="range">Range: ${mn(jiV).toFixed(1)} &ndash; ${mx(jiV).toFixed(1)}</div>
-  </div>
-  <div class="sec-card">
-    <div><div class="lbl">Packet Loss</div><div class="val">${aLo.toFixed(1)} %</div></div>
-    ${mn(loV) === mx(loV) && aLo === 0 ? '<div class="no-loss">No loss detected</div>' : `<div class="range">Range: ${mn(loV).toFixed(1)} &ndash; ${mx(loV).toFixed(1)}</div>`}
-  </div>
-</div>
-
-<hr class="divider">
-<h2>Use-Case Assessment</h2>
-<div class="uc-grid">
-  ${ucData.map(c => `<div class="uc-card" style="background:${ucBg(c.sc)};border-color:${ucColor(c.sc)}">
-    <div class="name">${c.l}</div>
-    <div class="score" style="color:${ucColor(c.sc)}">${c.sc}</div>
-    <div class="sub">${c.s}</div>
-  </div>`).join('')}
-</div>
-
-<hr class="divider">
-<h2>Test History</h2>
-<table>
-  <thead><tr><th>Date / Time</th><th>DL (Mbps)</th><th>UL (Mbps)</th><th>Ping (ms)</th><th>Jitter (ms)</th><th>Loss (%)</th><th></th></tr></thead>
-  <tbody>
-    ${hist.map(e => {
-            const d = new Date(e.timestamp);
-            const dt = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) + ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-            const isA = e.downloadSpeed !== undefined && e.downloadSpeed < anomThresh;
-            return `<tr class="${isA ? 'anomaly' : ''}">
-      <td class="${isA ? 'anom-dt' : ''}">${dt}</td>
-      <td class="${isA ? 'anom-dl' : 'dl'}">${e.downloadSpeed !== undefined ? e.downloadSpeed.toFixed(1) : '-'}</td>
-      <td class="ul">${e.uploadSpeed !== undefined ? e.uploadSpeed.toFixed(1) : '-'}</td>
-      <td class="pi">${e.ping !== undefined ? e.ping.toFixed(1) : '-'}</td>
-      <td>${e.jitter !== undefined ? e.jitter.toFixed(1) : '-'}</td>
-      <td>${e.packetLoss !== undefined ? e.packetLoss.toFixed(0) : '-'}</td>
-      <td>${isA ? '<span class="badge-anom">ANOMALY</span>' : ''}</td>
-    </tr>`;
-        }).join('')}
-  </tbody>
-</table>
-
-</body></html>`;
-
-        // Render HTML to hidden container, capture with html2canvas, save as PDF
-        const container = document.createElement('div');
-        container.style.cssText = 'position:fixed;left:-9999px;top:0;width:794px;visibility:visible;';
-        container.innerHTML = html.replace(/<!DOCTYPE html>[\s\S]*?<body[^>]*>/, '').replace(/<\/body>[\s\S]*/, '');
-
-        // Inject styles into container + override body padding as container padding
-        const styleMatch = html.match(/<style>([\s\S]*?)<\/style>/);
-        if (styleMatch) {
-            const styleEl = document.createElement('style');
-            styleEl.textContent = styleMatch[1];
-            container.prepend(styleEl);
-        }
-        // Apply body-level styles directly to container
-        container.style.background = '#0c0c14';
-        container.style.padding = '30px 40px';
-        container.style.fontFamily = "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
-        container.style.fontSize = '11px';
-        container.style.lineHeight = '1.5';
-        container.style.color = '#e8e8e8';
-
-        document.body.appendChild(container);
-
+    // --- Export dispatch ---
+    async function dispatchExport(kind: 'pdf' | 'json' | 'csv'): Promise<void> {
+        const all = await loadAllHistory();
+        if (all.length === 0) { statusEl.textContent = 'No data to export'; return; }
         try {
-            const { default: html2canvas } = await import('html2canvas');
-            const { jsPDF } = await import('jspdf');
-
-            const canvas = await html2canvas(container, {
-                backgroundColor: '#0c0c14',
-                scale: 2,
-                useCORS: true,
-                logging: false,
-                allowTaint: true,
-                foreignObjectRendering: false,
-            });
-
-            const pdfW = 210; // A4 width mm
-            const pdfH = 297; // A4 height mm
-            const margin = 8; // mm margin on each side
-            const contentW = pdfW - margin * 2;
-
-            const footerH = 12; // mm reserved for footer
-            const contHeaderH = 10; // mm reserved for "continued" header on page 2+
-            const page1ContentH = pdfH - margin * 2 - footerH;
-            const pageNContentH = pdfH - margin * 2 - footerH - contHeaderH;
-            const scaleFactor = canvas.width / contentW;
-            const slice1H = page1ContentH * scaleFactor;
-            const sliceNH = pageNContentH * scaleFactor;
-
-            // Calculate total pages
-            let remaining = canvas.height - slice1H;
-            let totalPages = 1;
-            while (remaining > 0) { totalPages++; remaining -= sliceNH; }
-
-            const doc = new jsPDF('p', 'mm', 'a4');
-            let srcOffset = 0;
-            for (let p = 0; p < totalPages; p++) {
-                if (p > 0) doc.addPage();
-                doc.setFillColor('#0c0c14');
-                doc.rect(0, 0, pdfW, pdfH, 'F');
-
-                const isFirst = p === 0;
-                const maxSlice = isFirst ? slice1H : sliceNH;
-                const topOffset = isFirst ? margin : margin + contHeaderH;
-                const srcH = Math.min(maxSlice, canvas.height - srcOffset);
-                const destH = srcH / scaleFactor;
-
-                const pageCanvas = document.createElement('canvas');
-                pageCanvas.width = canvas.width;
-                pageCanvas.height = srcH;
-                const ctx = pageCanvas.getContext('2d')!;
-                ctx.fillStyle = '#0c0c14';
-                ctx.fillRect(0, 0, pageCanvas.width, pageCanvas.height);
-                ctx.drawImage(canvas, 0, srcOffset, canvas.width, srcH, 0, 0, canvas.width, srcH);
-
-                doc.addImage(
-                    pageCanvas.toDataURL('image/png'),
-                    'PNG', margin, topOffset, contentW, destH,
-                    undefined, 'FAST'
-                );
-                srcOffset += srcH;
+            if (kind === 'pdf') {
+                statusEl.textContent = 'Generating report...';
+                await exportPdfReport(all);
+                statusEl.textContent = 'Report downloaded';
+            } else if (kind === 'json') {
+                exportJson(all);
+                statusEl.textContent = 'JSON exported';
+            } else {
+                exportCsv(all);
+                statusEl.textContent = 'CSV exported';
             }
+        } catch (e) {
+            statusEl.textContent = e instanceof Error ? `Export failed: ${e.message}` : 'Export failed';
+        }
+    }
 
-            // Draw footer + continuation header on every page
-            const footerY = pdfH - margin - 4;
-            for (let p = 1; p <= totalPages; p++) {
-                doc.setPage(p);
-                // Footer
-                doc.setDrawColor('#1e1e2e');
-                doc.line(margin, footerY - 4, pdfW - margin, footerY - 4);
-                doc.setFontSize(7);
-                doc.setTextColor('#555570');
-                doc.text('github.com/ajithakdev/meterx-server  |  v2026.0.319  |  AGPL-3.0', pdfW / 2, footerY, { align: 'center' });
-                doc.setTextColor('#8888a0');
-                doc.text(`${p} / ${totalPages}`, pdfW - margin, footerY, { align: 'right' });
-                // Continuation header on page 2+
-                if (p > 1) {
-                    doc.setFontSize(9);
-                    doc.setFont('helvetica', 'bold');
-                    doc.setTextColor('#e8e8e8');
-                    doc.text('Test History (continued)', margin, margin + 6);
-                    doc.setFont('helvetica', 'normal');
-                }
-            }
+    function closeExportMenu(): void {
+        exportMenu?.classList.add('hidden');
+        exportBackdrop?.classList.add('hidden');
+    }
+    function openExportMenu(): void {
+        exportMenu?.classList.remove('hidden');
+        exportBackdrop?.classList.remove('hidden');
+        const first = exportMenu?.querySelector<HTMLElement>('[data-export]');
+        first?.focus();
+    }
 
-            doc.save(`MeterX-Report-${now.toLocaleDateString('en-CA')}.pdf`);
-            statusEl.textContent = 'Report downloaded';
-        } catch {
-            statusEl.textContent = 'Export failed — try again';
-        } finally {
-            document.body.removeChild(container);
+    exportBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (exportMenu) {
+            if (exportMenu.classList.contains('hidden')) openExportMenu();
+            else closeExportMenu();
+        } else {
+            dispatchExport('pdf');
         }
     });
+
+    if (exportMenu) {
+        exportMenu.querySelectorAll<HTMLElement>('[data-export]').forEach(el => {
+            el.addEventListener('click', () => {
+                const kind = el.dataset.export as 'pdf' | 'json' | 'csv';
+                closeExportMenu();
+                dispatchExport(kind);
+            });
+        });
+        exportBackdrop?.addEventListener('click', closeExportMenu);
+        document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeExportMenu(); });
+    }
+
+    // --- Share ---
+    if (shareBtn) {
+        shareBtn.addEventListener('click', async () => {
+            const all = await loadAllHistory();
+            const last = all[0];
+            if (!last) { statusEl.textContent = 'No result to share'; return; }
+            const url = buildShareUrl(last);
+            try {
+                await navigator.clipboard.writeText(url);
+                statusEl.textContent = 'Share link copied';
+            } catch {
+                statusEl.textContent = url;
+            }
+        });
+    }
 });

--- a/packages/extension/src/quality.test.ts
+++ b/packages/extension/src/quality.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getQuality, getQualityClass, scoreUseCases } from './quality';
+
+describe('getQuality', () => {
+    it('grades excellent for 100/50/10ms', () => {
+        expect(getQuality(100, 50, 10).cls).toBe('excellent');
+    });
+    it('grades good for 25/15/40ms', () => {
+        expect(getQuality(25, 15, 40).cls).toBe('good');
+    });
+    it('grades fair for 10/5/100ms', () => {
+        expect(getQuality(10, 5, 100).cls).toBe('fair');
+    });
+    it('grades poor for 1/0.5/300ms', () => {
+        expect(getQuality(1, 0.5, 300).cls).toBe('poor');
+    });
+    it('downgrades if ping is bad even with great speed', () => {
+        expect(getQuality(500, 200, 500).cls).toBe('poor');
+    });
+});
+
+describe('getQualityClass', () => {
+    it('returns q-fair for undefined inputs', () => {
+        expect(getQualityClass(undefined, undefined, undefined)).toBe('q-fair');
+    });
+    it('prefixes q-', () => {
+        expect(getQualityClass(100, 50, 10)).toBe('q-excellent');
+    });
+});
+
+describe('scoreUseCases', () => {
+    it('scores gaming poor when loss is high', () => {
+        const s = scoreUseCases(100, 50, 10, 2, 5);
+        expect(s.gaming).toBe('poor');
+    });
+    it('scores gaming good on clean 30ms ping', () => {
+        const s = scoreUseCases(100, 50, 30, 5, 0);
+        expect(s.gaming).toBe('good');
+    });
+    it('scores streaming good at 50 Mbps down', () => {
+        expect(scoreUseCases(50, 5, 40).stream).toBe('good');
+    });
+    it('treats missing jitter as very bad', () => {
+        expect(scoreUseCases(100, 50, 10).calls).not.toBe('good');
+    });
+});

--- a/packages/extension/src/quality.ts
+++ b/packages/extension/src/quality.ts
@@ -1,0 +1,49 @@
+/**
+ * Quality scoring — shared between popup + PDF export
+ * @license AGPL-3.0
+ */
+
+import type { Quality } from '@meterx/shared';
+
+export interface QualityLabel {
+    label: string;
+    cls: Quality;
+}
+
+export function getQuality(dl: number, ul: number, ping: number): QualityLabel {
+    if (dl >= 50 && ul >= 20 && ping < 30) return { label: 'Excellent', cls: 'excellent' };
+    if (dl >= 20 && ul >= 10 && ping < 60) return { label: 'Good', cls: 'good' };
+    if (dl >= 5 && ul >= 2 && ping < 150) return { label: 'Fair', cls: 'fair' };
+    return { label: 'Poor', cls: 'poor' };
+}
+
+export function getQualityClass(dl?: number, ul?: number, ping?: number): string {
+    if (dl === undefined || ul === undefined || ping === undefined) return 'q-fair';
+    return 'q-' + getQuality(dl, ul, ping).cls;
+}
+
+export type UseCaseScore = 'good' | 'okay' | 'poor';
+
+export interface UseCaseScores {
+    calls: UseCaseScore;
+    stream: UseCaseScore;
+    gaming: UseCaseScore;
+    upload: UseCaseScore;
+}
+
+export function scoreUseCases(
+    dl: number,
+    ul: number,
+    ping: number,
+    jitter?: number,
+    loss?: number,
+): UseCaseScores {
+    const j = jitter ?? 999;
+    const l = loss ?? 100;
+    return {
+        calls:  (dl >= 5 && ul >= 3 && ping < 100 && j < 30) ? 'good' : (dl >= 2 && ul >= 1 && ping < 200) ? 'okay' : 'poor',
+        stream: dl >= 25 ? 'good' : dl >= 5 ? 'okay' : 'poor',
+        gaming: (ping < 50 && j < 20 && l < 1) ? 'good' : (ping < 100 && j < 40 && l < 3) ? 'okay' : 'poor',
+        upload: ul >= 10 ? 'good' : ul >= 3 ? 'okay' : 'poor',
+    };
+}

--- a/packages/extension/src/share.test.ts
+++ b/packages/extension/src/share.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildShareUrl, parseShareUrl } from './share';
+
+describe('share URL round-trip', () => {
+    it('encodes and decodes a full result', () => {
+        const entry = {
+            timestamp: 1_700_000_000_000,
+            downloadSpeed: 123.456,
+            uploadSpeed: 42.8,
+            ping: 18.3,
+            jitter: 2.1,
+            packetLoss: 0,
+            bufferbloatGrade: 'B' as const,
+            edge: 'BOM',
+        };
+        const url = buildShareUrl(entry);
+        expect(url).toContain('#r=');
+        const decoded = parseShareUrl(url);
+        expect(decoded).not.toBeNull();
+        expect(decoded!.timestamp).toBe(entry.timestamp);
+        expect(decoded!.downloadSpeed).toBeCloseTo(123.5, 1);
+        expect(decoded!.bufferbloatGrade).toBe('B');
+        expect(decoded!.edge).toBe('BOM');
+    });
+
+    it('returns null for malformed URL', () => {
+        expect(parseShareUrl('https://meterx.dev/share')).toBeNull();
+        expect(parseShareUrl('https://meterx.dev/share#r=!!!')).toBeNull();
+    });
+
+    it('handles entries with missing fields', () => {
+        const entry = { timestamp: 1_700_000_000_000 };
+        const decoded = parseShareUrl(buildShareUrl(entry));
+        expect(decoded!.timestamp).toBe(entry.timestamp);
+        expect(decoded!.downloadSpeed).toBeUndefined();
+    });
+});

--- a/packages/extension/src/share.ts
+++ b/packages/extension/src/share.ts
@@ -1,0 +1,61 @@
+/**
+ * Shareable result URL. v1 = hash-encoded payload, no server needed.
+ * A public viewer page at share target can later decode this fragment.
+ * @license AGPL-3.0
+ */
+
+import type { HistoryEntry } from '@meterx/shared';
+
+const SHARE_VIEWER = 'https://meterx.dev/share';
+
+export function buildShareUrl(entry: HistoryEntry): string {
+    const compact = {
+        t: entry.timestamp,
+        dl: roundOrNull(entry.downloadSpeed, 1),
+        ul: roundOrNull(entry.uploadSpeed, 1),
+        p:  roundOrNull(entry.ping, 1),
+        j:  roundOrNull(entry.jitter, 1),
+        l:  roundOrNull(entry.packetLoss, 1),
+        bb: entry.bufferbloatGrade ?? null,
+        e:  entry.edge ?? null,
+    };
+    const encoded = base64UrlEncode(JSON.stringify(compact));
+    return `${SHARE_VIEWER}#r=${encoded}`;
+}
+
+export function parseShareUrl(url: string): HistoryEntry | null {
+    try {
+        const hash = new URL(url).hash;
+        const match = hash.match(/r=([A-Za-z0-9_-]+)/);
+        if (!match) return null;
+        const json = base64UrlDecode(match[1]);
+        const c = JSON.parse(json);
+        return {
+            timestamp: c.t,
+            downloadSpeed: c.dl ?? undefined,
+            uploadSpeed:   c.ul ?? undefined,
+            ping:          c.p  ?? undefined,
+            jitter:        c.j  ?? undefined,
+            packetLoss:    c.l  ?? undefined,
+            bufferbloatGrade: c.bb ?? undefined,
+            edge: c.e ?? undefined,
+        };
+    } catch {
+        return null;
+    }
+}
+
+function roundOrNull(v: number | undefined, d: number): number | null {
+    if (v === undefined) return null;
+    return Number(v.toFixed(d));
+}
+
+function base64UrlEncode(s: string): string {
+    return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(s: string): string {
+    const pad = s.length % 4 ? '='.repeat(4 - (s.length % 4)) : '';
+    const b64 = (s + pad).replace(/-/g, '+').replace(/_/g, '/');
+    return decodeURIComponent(escape(atob(b64)));
+}

--- a/packages/extension/src/sidepanel.ts
+++ b/packages/extension/src/sidepanel.ts
@@ -1,0 +1,78 @@
+/**
+ * MeterX Side Panel — persistent dashboard next to the browser tab.
+ * @license AGPL-3.0
+ */
+
+/// <reference types="chrome" />
+
+import { loadAllHistory, loadHistory, renderHistory } from './history';
+import { renderIspComparison, loadIspPlan } from './isp';
+import { getQuality } from './quality';
+import { fmt } from './format';
+import { bindTooltips } from './tooltips';
+import { renderChart } from './chart';
+
+document.addEventListener('DOMContentLoaded', async () => {
+    const $ = (id: string) => document.getElementById(id) as HTMLElement;
+    const heroNum = $('heroNum');
+    const heroUp = $('heroUp');
+    const heroPing = $('heroPing');
+    const heroBB = $('heroBB');
+    const qualityBadge = $('quality-badge');
+    const chartEl = $('chart');
+    const historyListEl = $('historyList');
+    const ispEl = $('ispCompare');
+    const ispEmpty = $('ispEmpty');
+    const startBtn = $('startButton');
+    const optionsBtn = $('openOptions');
+
+    bindTooltips(document);
+
+    async function refresh(): Promise<void> {
+        const all = await loadAllHistory();
+        const last = all[0];
+
+        heroNum.textContent = fmt(last?.downloadSpeed, 1);
+        heroUp.textContent  = fmt(last?.uploadSpeed, 1);
+        heroPing.textContent = fmt(last?.ping, 1);
+        heroBB.textContent = last?.bufferbloatGrade ?? '--';
+
+        if (last && last.downloadSpeed !== undefined && last.uploadSpeed !== undefined && last.ping !== undefined) {
+            const q = getQuality(last.downloadSpeed, last.uploadSpeed, last.ping);
+            qualityBadge.textContent = q.label;
+            qualityBadge.className = `badge ${q.cls}`;
+        } else {
+            qualityBadge.classList.add('hidden');
+        }
+
+        renderChart(chartEl, all);
+        renderHistory(historyListEl, await loadHistory(10));
+
+        const plan = await loadIspPlan();
+        if (plan) {
+            ispEmpty.classList.add('hidden');
+            renderIspComparison(ispEl, last, plan);
+        } else {
+            ispEl.classList.add('hidden');
+            ispEmpty.classList.remove('hidden');
+        }
+    }
+
+    await refresh();
+
+    startBtn.addEventListener('click', () => {
+        chrome.runtime.sendMessage({ action: 'startTest' });
+    });
+    optionsBtn.addEventListener('click', () => chrome.runtime.openOptionsPage());
+
+    // Live-update when background finishes or history changes
+    chrome.runtime.onMessage.addListener((msg) => {
+        if (msg.action === 'testComplete' || msg.action === 'testError') {
+            setTimeout(refresh, 200);
+        }
+    });
+    chrome.storage.onChanged.addListener((changes, area) => {
+        if (area === 'local' && 'history' in changes) refresh();
+        if (area === 'sync' && ('ispPlan' in changes)) refresh();
+    });
+});

--- a/packages/extension/src/sparkline.ts
+++ b/packages/extension/src/sparkline.ts
@@ -1,0 +1,59 @@
+/**
+ * Tiny inline SVG sparkline for download-speed trend.
+ * Pure data -> markup; no runtime deps.
+ * @license AGPL-3.0
+ */
+
+import type { HistoryEntry } from '@meterx/shared';
+
+const W = 220;
+const H = 36;
+const PAD = 2;
+
+export function renderSparkline(el: HTMLElement, history: HistoryEntry[]): void {
+    const pts = history
+        .slice(0, 30)
+        .reverse()
+        .map(e => e.downloadSpeed)
+        .filter((v): v is number => v !== undefined);
+
+    if (pts.length < 2) {
+        el.innerHTML = '';
+        el.classList.add('hidden');
+        return;
+    }
+    el.classList.remove('hidden');
+
+    const max = Math.max(...pts);
+    const min = Math.min(...pts);
+    const range = max - min || 1;
+    const stepX = (W - PAD * 2) / (pts.length - 1);
+
+    const coords = pts.map((v, i) => {
+        const x = PAD + i * stepX;
+        const y = H - PAD - ((v - min) / range) * (H - PAD * 2);
+        return [x, y] as const;
+    });
+
+    const linePath = coords.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`).join(' ');
+    const areaPath = `${linePath} L${(W - PAD).toFixed(1)},${H - PAD} L${PAD},${H - PAD} Z`;
+
+    const latest = pts[pts.length - 1];
+    const latestX = coords[coords.length - 1][0].toFixed(1);
+    const latestY = coords[coords.length - 1][1].toFixed(1);
+
+    el.innerHTML = `
+      <svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="Download speed trend sparkline">
+        <defs>
+          <linearGradient id="sparkFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#00c8ff" stop-opacity="0.35"/>
+            <stop offset="100%" stop-color="#00c8ff" stop-opacity="0"/>
+          </linearGradient>
+        </defs>
+        <path d="${areaPath}" fill="url(#sparkFill)"/>
+        <path d="${linePath}" fill="none" stroke="#00c8ff" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="${latestX}" cy="${latestY}" r="2.2" fill="#00c8ff"/>
+      </svg>
+      <div class="spark-meta"><span>${pts.length} tests</span><span>${latest.toFixed(1)} Mbps</span></div>
+    `;
+}

--- a/packages/extension/src/tooltips.ts
+++ b/packages/extension/src/tooltips.ts
@@ -1,0 +1,67 @@
+/**
+ * Plain-language tooltips for jargon (jitter, packet loss, etc.).
+ * Reads content from [data-tip] attributes on elements.
+ * @license AGPL-3.0
+ */
+
+export const TOOLTIP_COPY: Record<string, string> = {
+    download:    'Speed coming in. Higher = faster pages.',
+    upload:      'Speed going out. Matters for calls, backups.',
+    ping:        'Round-trip delay. <30ms feels instant.',
+    jitter:      'Ping variation. Low = stable calls.',
+    'packet-loss': 'Lost packets. >1% causes stutters.',
+    quality:     'Overall grade: speed + ping + stability.',
+    bufferbloat: 'Ping spike under load. A = smooth, F = bad.',
+    'use-cases': 'Pass/fail for common activities.',
+};
+
+interface TipState {
+    tipEl: HTMLElement | null;
+    current: HTMLElement | null;
+}
+
+const state: TipState = { tipEl: null, current: null };
+
+function ensureTipEl(): HTMLElement {
+    if (state.tipEl) return state.tipEl;
+    const el = document.createElement('div');
+    el.className = 'mx-tooltip hidden';
+    el.setAttribute('role', 'tooltip');
+    document.body.appendChild(el);
+    state.tipEl = el;
+    return el;
+}
+
+function showTip(anchor: HTMLElement, text: string): void {
+    const tip = ensureTipEl();
+    tip.textContent = text;
+    tip.classList.remove('hidden');
+    const rect = anchor.getBoundingClientRect();
+    const tipRect = tip.getBoundingClientRect();
+    let left = rect.left + rect.width / 2 - tipRect.width / 2;
+    left = Math.max(6, Math.min(window.innerWidth - tipRect.width - 6, left));
+    const top = rect.bottom + 6;
+    tip.style.left = `${left}px`;
+    tip.style.top = `${top}px`;
+    state.current = anchor;
+}
+
+function hideTip(): void {
+    if (state.tipEl) state.tipEl.classList.add('hidden');
+    state.current = null;
+}
+
+export function bindTooltips(root: ParentNode): void {
+    const nodes = root.querySelectorAll<HTMLElement>('[data-tip]');
+    nodes.forEach(el => {
+        const key = el.dataset.tip!;
+        const text = TOOLTIP_COPY[key] ?? key;
+        el.setAttribute('aria-label', text);
+        el.setAttribute('tabindex', el.getAttribute('tabindex') ?? '0');
+        el.addEventListener('mouseenter', () => showTip(el, text));
+        el.addEventListener('mouseleave', hideTip);
+        el.addEventListener('focus',      () => showTip(el, text));
+        el.addEventListener('blur',       hideTip);
+    });
+    document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hideTip(); });
+}

--- a/packages/extension/static/manifest.json
+++ b/packages/extension/static/manifest.json
@@ -5,14 +5,19 @@
   "version": "2026.3.20.1",
   "description": "Open-source speed test. Measure download, upload, ping, jitter, packet loss with readiness labels and PDF reports.",
   "permissions": [
-    "storage"
+    "storage",
+    "alarms",
+    "notifications",
+    "sidePanel"
   ],
   "host_permissions": [
     "https://meterx-speedtest.meterx-ajithakdev.workers.dev/*"
   ],
   "optional_host_permissions": [
     "https://*/*",
-    "http://*/*"
+    "http://localhost/*",
+    "http://127.0.0.1/*",
+    "http://*.local/*"
   ],
   "options_page": "options.html",
   "action": {
@@ -22,6 +27,9 @@
       "48": "images/icons48.png",
       "128": "images/icons128.png"
     }
+  },
+  "side_panel": {
+    "default_path": "sidepanel.html"
   },
   "background": {
     "service_worker": "background.js"

--- a/packages/extension/static/options.css
+++ b/packages/extension/static/options.css
@@ -24,10 +24,27 @@ body {
     min-height: 100vh;
     display: flex;
     justify-content: center;
-    padding: 40px 20px;
+    padding: 28px 20px;
 }
 
-.container { width: 100%; max-width: 520px; }
+/* Fill near-full viewport but clamp on ultrawide so reading line length stays sane. */
+.container { width: 100%; max-width: 1680px; }
+
+/* Cards flow in responsive grid that fills wider viewports
+   instead of a narrow centered column. Status/actions/info stay full-width. */
+.options-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    gap: 14px;
+    align-items: start;
+    margin-bottom: 14px;
+}
+.options-grid > .card { margin-bottom: 0; }
+
+@media (max-width: 720px) {
+    body { padding: 20px 12px; }
+    .options-grid { grid-template-columns: 1fr; }
+}
 
 .header {
     display: flex;
@@ -176,3 +193,25 @@ input[type="url"]::placeholder { color: var(--t3); }
 .footer { font-size: 11px; color: var(--t3); text-align: center; }
 .footer a { color: var(--t3); text-decoration: none; transition: color 0.15s; }
 .footer a:hover { color: var(--cyan); }
+
+/* ISP plan card — grid children need min-width:0 so inputs don't push past card edge at zoom */
+.isp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 10px; }
+.isp-field { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.isp-field-wide { grid-column: 1 / -1; }
+.isp-fl { font-size: 11px; color: var(--t2); }
+.isp-field input {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 8px 10px;
+    color: var(--t1);
+    font-family: var(--font);
+    font-size: 12px;
+    outline: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+}
+.isp-field input:focus { border-color: var(--cyan); }
+.isp-actions { display: flex; justify-content: flex-end; gap: 8px; }

--- a/packages/extension/static/options.html
+++ b/packages/extension/static/options.html
@@ -28,6 +28,7 @@
             </div>
         </div>
 
+        <div class="options-grid">
         <!-- Server Selection -->
         <div class="card">
             <label>Server</label>
@@ -55,6 +56,45 @@
                 </div>
                 <div id="testStatus" class="test-status hidden"></div>
             </div>
+        </div>
+
+        <!-- ISP Plan -->
+        <div class="card">
+            <label>Your ISP plan (optional)</label>
+            <p class="radio-desc" style="margin-bottom:10px">Enter your advertised speeds to see how much of what you pay for you actually get.</p>
+            <div class="isp-grid">
+                <div class="isp-field">
+                    <label for="ispDown" class="isp-fl">Download (Mbps)</label>
+                    <input type="number" min="0" step="1" id="ispDown" placeholder="e.g. 300">
+                </div>
+                <div class="isp-field">
+                    <label for="ispUp" class="isp-fl">Upload (Mbps)</label>
+                    <input type="number" min="0" step="1" id="ispUp" placeholder="e.g. 100">
+                </div>
+                <div class="isp-field isp-field-wide">
+                    <label for="ispProvider" class="isp-fl">Provider (optional)</label>
+                    <input type="text" id="ispProvider" placeholder="e.g. Airtel" maxlength="40">
+                </div>
+            </div>
+            <div class="isp-actions">
+                <button id="ispClearBtn" type="button" class="btn btn-secondary">Clear</button>
+            </div>
+        </div>
+
+        <!-- Scheduled background tests -->
+        <div class="card">
+            <label>Scheduled background tests</label>
+            <p class="radio-desc" style="margin-bottom:10px">Run a quick check on a timer. Get a notification if quality drops.</p>
+            <div class="radio-group">
+                <label class="radio-option"><input type="radio" name="schedule" value="off" checked><div class="radio-content"><span class="radio-label">Off</span><span class="radio-desc">Only run tests when I click.</span></div></label>
+                <label class="radio-option"><input type="radio" name="schedule" value="30"><div class="radio-content"><span class="radio-label">Every 30 min</span><span class="radio-desc">Frequent &mdash; best for troubleshooting a flaky connection.</span></div></label>
+                <label class="radio-option"><input type="radio" name="schedule" value="120"><div class="radio-content"><span class="radio-label">Every 2 hours</span><span class="radio-desc">Balanced default.</span></div></label>
+                <label class="radio-option"><input type="radio" name="schedule" value="1440"><div class="radio-content"><span class="radio-label">Once a day</span><span class="radio-desc">Low overhead trend data.</span></div></label>
+            </div>
+            <label class="isp-fl" style="display:flex;align-items:center;gap:8px;margin-top:10px">
+                <input type="checkbox" id="notifyOnDrop"> Notify when quality drops to Poor
+            </label>
+        </div>
         </div>
 
         <div class="actions">

--- a/packages/extension/static/popup.css
+++ b/packages/extension/static/popup.css
@@ -435,3 +435,122 @@ footer {
 
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.5}}
 .testing .speed-number{animation:pulse 1.2s ease-in-out infinite}
+
+/* ── Tooltips ── */
+.mx-tooltip{
+    position:fixed;
+    max-width:220px;
+    background:#17171f;
+    color:var(--t1);
+    border:1px solid rgba(255,255,255,0.08);
+    border-radius:6px;
+    padding:8px 10px;
+    font-size:11px;
+    line-height:1.4;
+    box-shadow:0 8px 24px rgba(0,0,0,0.6);
+    pointer-events:none;
+    z-index:9999;
+}
+[data-tip]{cursor:help}
+[data-tip]:focus{outline:1px dashed var(--t3);outline-offset:2px}
+
+/* ── Sparkline ── */
+.sparkline{
+    margin:8px 0 6px;
+    padding:8px 10px;
+    background:var(--bg-card);
+    border:1px solid var(--border);
+    border-radius:var(--r);
+    display:flex;
+    flex-direction:column;
+    gap:2px;
+}
+.sparkline svg{display:block;width:100%;height:auto}
+.spark-meta{
+    display:flex;
+    justify-content:space-between;
+    font-family:var(--mono);
+    font-size:9px;
+    color:var(--t3);
+    text-transform:uppercase;
+    letter-spacing:0.04em;
+}
+
+/* ── ISP compare ── */
+.isp-compare{
+    margin:6px 0;
+    padding:8px 10px;
+    background:var(--bg-card);
+    border:1px solid var(--border);
+    border-radius:var(--r);
+    font-size:11px;
+}
+.isp-head{
+    display:flex;
+    justify-content:space-between;
+    color:var(--t2);
+    margin-bottom:6px;
+    font-size:10px;
+    text-transform:uppercase;
+    letter-spacing:0.04em;
+}
+.isp-plan{font-family:var(--mono);color:var(--t1)}
+.isp-bars{display:flex;flex-direction:column;gap:3px}
+.isp-row{display:flex;justify-content:space-between;padding:3px 6px;border-radius:6px;font-family:var(--mono)}
+.isp-row.ok{background:rgba(52,211,153,0.10);color:#34d399}
+.isp-row.warn{background:rgba(251,191,36,0.10);color:#fbbf24}
+.isp-row.bad{background:rgba(248,113,113,0.10);color:#f87171}
+.isp-row .isp-k{color:var(--t2);font-family:var(--font)}
+
+/* ── Export dropdown — floats over popup center to avoid body scroll ── */
+.history-actions{display:flex;gap:10px;align-items:center;line-height:1}
+.history-actions > *{display:inline-flex;align-items:center;line-height:1}
+.export-wrap{position:relative;display:inline-flex;align-items:center}
+.export-backdrop{
+    position:fixed;
+    inset:0;
+    background:rgba(0,0,0,0.45);
+    backdrop-filter:blur(2px);
+    z-index:9998;
+}
+.export-menu{
+    position:fixed;
+    left:50%;
+    top:50%;
+    transform:translate(-50%,-50%);
+    background:#17171f;
+    border:1px solid rgba(255,255,255,0.10);
+    border-radius:10px;
+    box-shadow:0 12px 32px rgba(0,0,0,0.75);
+    padding:6px;
+    min-width:200px;
+    z-index:9999;
+}
+.export-menu-title{
+    font-size:10px;
+    text-transform:uppercase;
+    letter-spacing:0.06em;
+    color:var(--t3);
+    padding:6px 10px 4px;
+}
+.export-menu button{
+    display:block;
+    width:100%;
+    text-align:left;
+    padding:10px 12px;
+    background:none;
+    border:none;
+    color:var(--t1);
+    font-size:12px;
+    border-radius:6px;
+    cursor:pointer;
+    font-family:var(--font);
+}
+.export-menu button:hover,
+.export-menu button:focus{background:var(--bg-card-h);outline:none}
+.export-menu .export-sub{
+    display:block;
+    font-size:10px;
+    color:var(--t3);
+    margin-top:2px;
+}

--- a/packages/extension/static/popup.html
+++ b/packages/extension/static/popup.html
@@ -17,7 +17,7 @@
                 <span class="brand-name">MeterX</span>
             </div>
             <div class="header-right">
-                <div id="quality-badge" class="badge hidden" aria-live="polite"></div>
+                <div id="quality-badge" class="badge hidden" aria-live="polite" data-tip="quality"></div>
                 <button id="settingsBtn" class="icon-btn" aria-label="Settings" title="Settings"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
                 <button id="closeBtn" class="close-btn" aria-label="Close popup"><svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="1" y1="1" x2="9" y2="9"/><line x1="9" y1="1" x2="1" y2="9"/></svg></button>
             </div>
@@ -57,26 +57,32 @@
         </div>
 
         <!-- Use-Case Readiness -->
-        <div id="use-cases" class="use-cases hidden">
+        <div id="use-cases" class="use-cases hidden" data-tip="use-cases">
             <div class="uc" id="uc-calls"><span class="uc-dot"></span>Calls</div>
             <div class="uc" id="uc-stream"><span class="uc-dot"></span>Streaming</div>
             <div class="uc" id="uc-gaming"><span class="uc-dot"></span>Gaming</div>
             <div class="uc" id="uc-upload"><span class="uc-dot"></span>Uploads</div>
         </div>
 
+        <!-- ISP plan comparison (hidden until plan configured in options) -->
+        <div id="ispCompare" class="isp-compare hidden" aria-live="polite"></div>
+
+        <!-- Sparkline trend -->
+        <div id="sparkline" class="sparkline hidden" aria-hidden="true"></div>
+
         <!-- Stats — compact row -->
         <div class="stats">
-            <div class="stat-item">
+            <div class="stat-item" data-tip="ping">
                 <span class="stat-val" id="ping">--</span>
                 <span class="stat-lbl">Ping <span class="stat-u">ms</span></span>
             </div>
             <div class="stat-sep"></div>
-            <div class="stat-item">
+            <div class="stat-item" data-tip="jitter">
                 <span class="stat-val" id="jitter">--</span>
                 <span class="stat-lbl">Jitter <span class="stat-u">ms</span></span>
             </div>
             <div class="stat-sep"></div>
-            <div class="stat-item">
+            <div class="stat-item" data-tip="packet-loss">
                 <span class="stat-val" id="packetLoss">--</span>
                 <span class="stat-lbl">Loss <span class="stat-u">%</span></span>
             </div>
@@ -101,10 +107,25 @@
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
                     <span id="historyLabel">History</span>
                 </button>
-                <button id="exportBtn" class="ghost-btn" aria-label="Export PDF report">
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-                    Report
-                </button>
+                <div class="history-actions">
+                    <button id="shareBtn" class="ghost-btn" aria-label="Copy shareable result link" title="Copy share link">
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+                        Share
+                    </button>
+                    <div class="export-wrap">
+                        <button id="exportBtn" class="ghost-btn" aria-label="Export results" aria-haspopup="menu">
+                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                            Export
+                        </button>
+                        <div id="exportBackdrop" class="export-backdrop hidden"></div>
+                        <div id="exportMenu" class="export-menu hidden" role="menu" aria-label="Export format">
+                            <div class="export-menu-title">Export results</div>
+                            <button type="button" role="menuitem" data-export="pdf">PDF report<span class="export-sub">Styled dashboard for sharing</span></button>
+                            <button type="button" role="menuitem" data-export="json">JSON<span class="export-sub">Machine-readable, full fields</span></button>
+                            <button type="button" role="menuitem" data-export="csv">CSV<span class="export-sub">Spreadsheet friendly</span></button>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div id="historyList" class="history-list hidden"></div>
         </div>

--- a/packages/extension/static/sidepanel.css
+++ b/packages/extension/static/sidepanel.css
@@ -1,0 +1,20 @@
+body.sidepanel, html { width: 100%; min-width: 280px; }
+.sp-container { display:flex; flex-direction:column; gap:16px; padding:14px; }
+.sp-header { display:flex; align-items:center; justify-content:space-between; }
+.sp-h2 { font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:var(--t2); margin-bottom:8px; }
+.sp-hero { display:flex; align-items:flex-end; justify-content:space-between; padding:14px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r); }
+.sp-hero-main { display:flex; align-items:baseline; gap:6px; }
+.sp-hero-num { font-family:var(--mono); font-size:38px; font-weight:700; color:var(--dl); }
+.sp-hero-unit { font-size:12px; color:var(--t2); }
+.sp-hero-side { display:flex; flex-direction:column; gap:2px; font-family:var(--mono); font-size:11px; color:var(--t2); text-align:right; }
+.sp-hero-side span { color:var(--t1); }
+.sp-chart { width:100%; height:140px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--r); padding:10px; }
+.sp-empty { color:var(--t3); font-size:11px; }
+.sp-actions { display:flex; gap:8px; }
+.sp-primary, .sp-secondary { flex:1; padding:10px; border-radius:var(--r); border:1px solid var(--border); font-size:12px; cursor:pointer; font-family:var(--font); }
+.sp-primary { background:var(--btn); color:#fff; border-color:var(--btn); }
+.sp-primary:hover { background:var(--btn-h); }
+.sp-secondary { background:var(--bg-card); color:var(--t1); }
+.sp-secondary:hover { background:var(--bg-card-h); }
+.sp-footer { text-align:center; font-size:10px; color:var(--t3); }
+.sp-footer a { color:var(--t2); }

--- a/packages/extension/static/sidepanel.html
+++ b/packages/extension/static/sidepanel.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>MeterX — Network Dashboard</title>
+    <link rel="stylesheet" href="popup.css">
+    <link rel="stylesheet" href="sidepanel.css">
+</head>
+<body class="sidepanel">
+    <div class="sp-container">
+        <header class="sp-header">
+            <div class="brand">
+                <span class="logo">MX</span>
+                <span class="brand-name">MeterX Dashboard</span>
+            </div>
+            <div id="quality-badge" class="badge hidden" aria-live="polite" data-tip="quality"></div>
+        </header>
+
+        <section class="sp-hero">
+            <div class="sp-hero-main">
+                <span class="sp-hero-num" id="heroNum">--</span>
+                <span class="sp-hero-unit">Mbps ↓</span>
+            </div>
+            <div class="sp-hero-side">
+                <div class="sp-sub"><span id="heroUp">--</span> Mbps ↑</div>
+                <div class="sp-sub"><span id="heroPing">--</span> ms ping</div>
+                <div class="sp-sub"><span id="heroBB">--</span> bufferbloat</div>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="sp-h2">Trend</h2>
+            <div id="chart" class="sp-chart" aria-label="Download speed over time"></div>
+        </section>
+
+        <section>
+            <h2 class="sp-h2">ISP Plan</h2>
+            <div id="ispCompare" class="isp-compare hidden" aria-live="polite"></div>
+            <p id="ispEmpty" class="sp-empty">Set your ISP plan in Settings to see how much of what you pay for you are getting.</p>
+        </section>
+
+        <section>
+            <h2 class="sp-h2">Recent Tests</h2>
+            <div id="historyList" class="history-list"></div>
+        </section>
+
+        <div class="sp-actions">
+            <button id="startButton" class="sp-primary">Run test</button>
+            <button id="openOptions" class="sp-secondary">Settings</button>
+        </div>
+
+        <footer class="sp-footer">
+            MeterX &middot; <a href="https://github.com/ajithakdev/meterx-server" target="_blank">source</a>
+        </footer>
+    </div>
+    <script src="sidepanel.js"></script>
+</body>
+</html>

--- a/packages/extension/vitest.config.mjs
+++ b/packages/extension/vitest.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['src/**/*.test.ts'],
+    },
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
+    "@meterx/shared": "*"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -43,6 +43,20 @@ describe('GET /test-file/:filename', () => {
     });
 });
 
+describe('GET /ip', () => {
+    it('returns connecting IP and family', async () => {
+        const res = await request(app).get('/ip');
+        expect(res.status).toBe(200);
+        expect(res.body).toHaveProperty('family');
+        expect(['ipv4', 'ipv6', 'unknown']).toContain(res.body.family);
+    });
+
+    it('sets Timing-Allow-Origin', async () => {
+        const res = await request(app).get('/ip');
+        expect(res.headers['timing-allow-origin']).toBe('*');
+    });
+});
+
 describe('POST /upload', () => {
     it('accepts octet-stream upload', async () => {
         const res = await request(app)

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -33,9 +33,11 @@ app.use(cors({
 }));
 
 // --- Rate limiting ---
-const pingLimiter = rateLimit({ windowMs: 60000, max: 60, standardHeaders: true, legacyHeaders: false, message: 'Too many ping requests.' });
-const downloadLimiter = rateLimit({ windowMs: 60000, max: 10, standardHeaders: true, legacyHeaders: false, message: 'Too many download requests.' });
-const uploadLimiter = rateLimit({ windowMs: 60000, max: 10, standardHeaders: true, legacyHeaders: false, message: 'Too many upload requests.' });
+// Higher buckets to allow multi-stream duration-based tests (4 parallel x ~8s window
+// can emit 8-16 requests per test). Ping probes the loaded-ping probe needs room too.
+const pingLimiter = rateLimit({ windowMs: 60000, max: 240, standardHeaders: true, legacyHeaders: false, message: 'Too many ping requests.' });
+const downloadLimiter = rateLimit({ windowMs: 60000, max: 120, standardHeaders: true, legacyHeaders: false, message: 'Too many download requests.' });
+const uploadLimiter = rateLimit({ windowMs: 60000, max: 120, standardHeaders: true, legacyHeaders: false, message: 'Too many upload requests.' });
 
 app.use(express.raw({ type: 'application/octet-stream', limit: '10mb' }));
 
@@ -85,5 +87,13 @@ app.post('/upload', uploadLimiter, (req: Request, res: Response) => {
 app.head('/ping', pingLimiter, (_req: Request, res: Response) => { res.status(200).end(); });
 app.get('/ping', pingLimiter, (_req: Request, res: Response) => { res.status(200).send('Pong!'); });
 app.get('/health', (_req: Request, res: Response) => { res.status(200).json({ status: 'ok', version: '2026.0.319-MR1.0' }); });
+
+app.get('/ip', pingLimiter, (req: Request, res: Response) => {
+    const ip = String(req.ip || '');
+    const family: 'ipv4' | 'ipv6' | 'unknown' = ip.includes(':') ? 'ipv6' : ip.match(/^\d+\.\d+\.\d+\.\d+$/) ? 'ipv4' : 'unknown';
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Timing-Allow-Origin', '*');
+    res.status(200).json({ ip, family });
+});
 
 export default app;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@meterx/shared",
+  "version": "1.0.0",
+  "private": true,
+  "license": "AGPL-3.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,84 @@
+/**
+ * MeterX Shared Types
+ * @license AGPL-3.0
+ */
+
+export type Quality = 'excellent' | 'good' | 'fair' | 'poor';
+
+export interface TestProgress {
+    status?: string;
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    ping?: number;
+    jitter?: number;
+    packetLoss?: number;
+    bufferbloatDelta?: number;
+    dnsLookupMs?: number;
+}
+
+export interface TestResults {
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    ping?: number;
+    jitter?: number;
+    packetLoss?: number;
+    bufferbloatDelta?: number;
+    bufferbloatGrade?: 'A' | 'B' | 'C' | 'D' | 'F';
+    dnsLookupMs?: number;
+    ipv4Ok?: boolean;
+    ipv6Ok?: boolean;
+    status: string;
+    serverUrl?: string;
+    edge?: string;
+    timestamp?: number;
+}
+
+export interface PingResult {
+    ping: number;
+    jitter: number;
+    packetLoss: number;
+    samples?: number[];
+}
+
+export interface HealthResponse {
+    status: 'ok' | 'degraded';
+    server: 'cloudflare-worker' | 'express';
+    version?: string;
+    edge?: string;
+    timestamp: number;
+}
+
+export interface HistoryEntry {
+    id?: string;
+    timestamp: number;
+    downloadSpeed?: number;
+    uploadSpeed?: number;
+    ping?: number;
+    jitter?: number;
+    packetLoss?: number;
+    bufferbloatDelta?: number;
+    bufferbloatGrade?: 'A' | 'B' | 'C' | 'D' | 'F';
+    dnsLookupMs?: number;
+    ipv4Ok?: boolean;
+    ipv6Ok?: boolean;
+    edge?: string;
+}
+
+export interface IspPlan {
+    downloadMbps: number;
+    uploadMbps: number;
+    providerName?: string;
+}
+
+export const QUALITY_THRESHOLDS = {
+    excellent: { download: 100, upload: 20, ping: 30, jitter: 10, packetLoss: 0.5 },
+    good:      { download: 25,  upload: 5,  ping: 60, jitter: 20, packetLoss: 1   },
+    fair:      { download: 5,   upload: 1,  ping: 120, jitter: 40, packetLoss: 3  },
+} as const;
+
+export const USE_CASE_REQUIREMENTS = {
+    calls:     { minDownload: 1,  minUpload: 1,  maxPing: 150, maxJitter: 30, maxPacketLoss: 1 },
+    streaming: { minDownload: 5,  minUpload: 0,  maxPing: 200, maxJitter: 60, maxPacketLoss: 2 },
+    gaming:    { minDownload: 3,  minUpload: 1,  maxPing: 50,  maxJitter: 15, maxPacketLoss: 0.5 },
+    uploads:   { minDownload: 0,  minUpload: 5,  maxPing: 200, maxJitter: 60, maxPacketLoss: 2 },
+} as const;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -10,6 +10,9 @@
     "deploy": "wrangler deploy",
     "build": "echo 'Worker is built by wrangler on deploy'"
   },
+  "dependencies": {
+    "@meterx/shared": "*"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250313.0",
     "wrangler": "^4.8.0"

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -28,6 +28,9 @@ function corsHeaders(request: Request): HeadersInit {
         'Access-Control-Allow-Methods': 'GET, POST, HEAD, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Max-Age': '86400',
+        // Allow Resource Timing API (domainLookup*/connect*) to surface across origins
+        // so the extension can extract DNS lookup time.
+        'Timing-Allow-Origin': allowed ? origin : '',
     };
 }
 
@@ -127,6 +130,28 @@ function handlePing(request: Request, method: string): Response {
 }
 
 /**
+ * Route handler: GET /ip
+ * Reflects the connecting IP + family so the extension can detect IPv4/IPv6 reachability.
+ * No PII stored, only returned to the caller in-band.
+ */
+function handleIp(request: Request): Response {
+    const ip = request.headers.get('cf-connecting-ip') || '';
+    const family: 'ipv4' | 'ipv6' | 'unknown' = ip.includes(':') ? 'ipv6' : ip.match(/^\d+\.\d+\.\d+\.\d+$/) ? 'ipv4' : 'unknown';
+    return new Response(
+        JSON.stringify({ ip, family }),
+        {
+            status: 200,
+            headers: {
+                ...corsHeaders(request),
+                'Content-Type': 'application/json',
+                'Cache-Control': 'no-store',
+                'Timing-Allow-Origin': '*',
+            },
+        }
+    );
+}
+
+/**
  * Route handler: GET /health
  * Returns server status and edge location.
  */
@@ -182,6 +207,11 @@ export default {
         // Route: /health
         if (path === '/health' && method === 'GET') {
             return handleHealth(request);
+        }
+
+        // Route: /ip
+        if (path === '/ip' && method === 'GET') {
+            return handleIp(request);
         }
 
         // 404 for everything else


### PR DESCRIPTION
## Summary

Major feature drop + accuracy overhaul, aiming to make MeterX a must-have network tool for both technical and non-technical browser users.

### Headline changes
- **Accurate measurement**: multi-stream (4 parallel DL, 3 parallel UL) duration-based tests with ramp-up and tail trimming — matches M-Lab/Ookla methodology. Saturates fat pipes the old single-stream 10MB couldn't reach.
- **Bufferbloat grade (A–F)**: loaded-ping probe during download yields a latency-under-load delta vs idle ping.
- **DNS timing + IPv4/IPv6 detection**: new `/ip` endpoint on worker and server; `Timing-Allow-Origin` added so the Resource Timing API can surface DNS lookup time to the extension.
- **Side panel dashboard**: MV3 side panel with multi-series SVG trend chart, ISP comparison, history, and a run button. Persistent while browsing.
- **Scheduled background tests**: `chrome.alarms`-driven off / 30m / 2h / daily cadence with optional `chrome.notifications` on quality drop to Poor.
- **ISP plan comparison**: user enters advertised plan in Options → popup and side panel show delivered % of paid.
- **Shareable result URLs**: hash-encoded base64url payload, stateless — no server storage required. (Viewer page at `meterx.dev/share` to be shipped separately; see `DESIGN_SESSION_GUIDE` / next iteration.)
- **JSON + CSV export** alongside PDF for machine-readable workflows.
- **Plain-language tooltips** via `data-tip` attributes — explains jitter / packet loss / bufferbloat / ping for non-technical users.

### Bug fixes
- **Download timing bug** (`background.ts`): non-streaming fallback computed `endTime - performance.now()` ≈ 0 → fallback to 1s constant. Now captures `fallbackStart` before `arrayBuffer()`.
- **Test hanging after download** (`background.ts`): loaded-ping probe `stop()` cleared the inner sleep `setTimeout` but never called its `resolve()`, so `await runner` hung forever → upload never started. Now captures and invokes `resolve` on stop.
- **Export menu scrollbar** (`popup.css`): absolute-positioned dropdown pushed popup body into scroll. Now a fixed-position centered overlay with dim backdrop, Escape-to-close, click-backdrop-to-close.
- **ISP input overflow at 175% zoom** (`options.css`): grid children defaulted `min-width:auto`, pushing inputs past card edge. Fixed with `min-width:0` on `.isp-field` + `width:100%; max-width:100%; box-sizing:border-box` on inputs.
- **Share/Export button baseline misalignment** (`popup.css`): `.export-wrap` wasn't a flex child. Enforced `inline-flex; align-items:center; line-height:1` on `.history-actions > *`.
- **Manifest permission overreach**: `optional_host_permissions` dropped `http://*/*`. Now `https://*/*` + `localhost/127.0.0.1/*.local`. Options page validates URL scheme before `chrome.permissions.request`.

### Architecture
- New `@meterx/shared` workspace package — all cross-package types live here (`TestProgress`, `TestResults`, `HistoryEntry`, `IspPlan`, `HealthResponse`, `QUALITY_THRESHOLDS`, `USE_CASE_REQUIREMENTS`).
- `popup.ts` split from 717 lines into focused modules: `quality.ts`, `history.ts`, `format.ts`, `export-pdf.ts`, `export-data.ts`, `share.ts`, `sparkline.ts`, `tooltips.ts`, `isp.ts`, `chart.ts`.
- Options page converted to responsive auto-fit grid (`max-width: 1680px`) — fills wider viewports instead of the previous narrow 520px column.
- Server rate limits bumped (`ping 60→240`, `download/upload 10→120`) to accommodate multi-stream test load without triggering 429s.
- Extension added vitest config (`vitest.config.mjs`) + 21 unit tests covering quality grading, time formatting, share URL round-trip.

### Files changed
- **Added (24)**: `packages/shared/*`, `packages/extension/src/chart.ts`, `export-data.ts`, `export-pdf.ts`, `format.ts`, `format.test.ts`, `history.ts`, `isp.ts`, `quality.ts`, `quality.test.ts`, `share.ts`, `share.test.ts`, `sidepanel.ts`, `sparkline.ts`, `tooltips.ts`, `static/sidepanel.html`, `static/sidepanel.css`, `vitest.config.mjs`
- **Modified (13)**: extension `background.ts`, `options.ts`, `popup.ts`, `manifest.json`, `options.html`, `options.css`, `popup.html`, `popup.css`, `build.mjs`, `package.json`; server `app.ts`, `app.test.ts`, `package.json`; worker `src/index.ts`, `package.json`; root `.gitignore`

## Test plan

### Automated
- [x] `npm run lint` — 0 errors (6 pre-existing CSS baseline warnings acceptable)
- [x] `npm run build` — all 3 workspaces build cleanly
- [x] `npm test` — 31/31 passing (21 extension + 10 server)

### Manual — extension
- [ ] Load `packages/extension/dist/` as unpacked in Chrome / Edge dev mode
- [ ] Click toolbar icon → popup opens, quality badge, sparkline, stats render
- [ ] Click **Start Test** → full DL / UL / Ping sequence runs start-to-finish (no hang after DL) in ~17–20s
- [ ] Verify DL/UL numbers are in same ballpark as Google / fast.com (multi-stream should now saturate)
- [ ] Click **Export** → overlay appears centered, no body scroll; try PDF / JSON / CSV each
- [ ] Click **Share** → clipboard copies URL containing `#r=<base64url>`
- [ ] Open Options page → responsive layout fills ultrawide screen; cards side-by-side ≥ 720px, stacked below
- [ ] Zoom browser to 175% on Options → ISP inputs stay inside their card
- [ ] Enter ISP plan (e.g. 300 / 100) → save → reopen popup → ISP comparison card shows % of paid
- [ ] Set scheduled tests to "Every 30 min" + tick Notify → save → verify `chrome.alarms` registered via `chrome://extensions` service worker inspector
- [ ] Open side panel (via Chrome side-panel UI) → trend chart + ISP compare + history render
- [ ] Run second test → side panel live-updates without reload
- [ ] Hover / focus a stat label → tooltip appears with short plain-language copy

### Manual — worker / server
- [ ] Redeploy worker: `cd packages/worker && npx wrangler deploy`
- [ ] Verify `curl https://meterx-speedtest.meterx-ajithakdev.workers.dev/ip` → `{"ip":"...","family":"ipv4"|"ipv6"|"unknown"}`
- [ ] Verify `/ip` response carries `Timing-Allow-Origin: *`
- [ ] Self-host server: `npm start` → `curl http://localhost:3000/ip` returns same schema
- [ ] Run an extension test after worker redeploy → JSON export now populates `ipv4Ok` / `ipv6Ok` / `edge` fields (empty before redeploy)

### Known follow-ups (not in this PR)
- Share viewer page at `meterx.dev/share` (decodes `#r=` → renders result card). Design brief stubbed for next session.
- First-install onboarding HTML (`welcome.html`).
- Chrome / Edge store promotional tiles + listing copy.
- OG preview image template for shareable URL embeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)